### PR TITLE
Fix inclusion of auto-generated headers

### DIFF
--- a/pass/LoopSplit/LoopSplit.cpp
+++ b/pass/LoopSplit/LoopSplit.cpp
@@ -14,9 +14,6 @@
 // split.
 //===----------------------------------------------------------------------===//
 
-#define GEN_PASS_CLASSES
-#include "Passes.h.inc"
-
 #define DEBUG_TYPE "triton-loop-split"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 #define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
@@ -204,7 +201,12 @@ LogicalResult LoopBisect::bisect() {
   return success();
 }
 
-struct LoopBisectPass : public TritonLoopSplitBase<LoopBisectPass> {
+// To make available the auto-generated base classes in the `impl`
+// namespace, we drop in the generated headers from `Passes.td`.
+#define GEN_PASS_DEF_TRITONLOOPSPLIT
+#include "Passes.h.inc"
+
+struct LoopBisectPass : public impl::TritonLoopSplitBase<LoopBisectPass> {
   LoopBisectPass() = default;
 
   void runOnOperation() override {


### PR DESCRIPTION
Previously, this used a deprecated mechanism for including the auto-generated TableGen headers. Here we update it to use the new macro definition and fix some namespacing issues (`impl::`) that otherwise kept this from compiling.