### PR TITLE
Fix TRITON_EXT_NAMES for CMake list functions

### DIFF
--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -71,9 +71,9 @@ function(triton_ext_should_build_extension triton_ext_dir result_var)
                 string(STRIP "${_ext_name}" _ext_name)
             endif()
             # Check if _ext_name is in TRITON_EXT_NAMES
-            list(LENGTH "${TRITON_EXT_NAMES}" _size)
+            list(LENGTH TRITON_EXT_NAMES _size)
             if(NOT _size EQUAL 0)
-                list(FIND "${TRITON_EXT_NAMES}" "${_ext_name}" _index)
+                list(FIND TRITON_EXT_NAMES "${_ext_name}" _index)
                 if(NOT _index EQUAL -1)
                     # If _ext_name is in TRITON_EXT_NAMES, set result to TRUE
                     set(${result_var} TRUE PARENT_SCOPE)


### PR DESCRIPTION
Cmake list argument `TRITON_EXT_NAMES` should not be expanded or quoted. Without this fix, the `TRITON_EXT_NAMES` variable is essentially ignored and all passes are built in every configuration.