### PR TITLE
Format all `*.md` files

### DIFF
--- a/.markdownlint-cli
+++ b/.markdownlint-cli
@@ -1,0 +1,14 @@
+default: true
+fix: true
+# Line length.
+MD013:
+  line_length: 80
+  tables: false
+  code_blocks: false
+# Multiple headings with the same content.
+MD024: false
+# Inline HTML.
+MD033:
+  allowed_elements: [a, p, img]
+# Images should have alternate text (alt text).
+MD045: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,20 @@ repos:
       - id: detect-private-key
       - id: debug-statements
 
+  - repo: https://github.com/executablebooks/mdformat
+    rev: 1.0.0
+    hooks:
+      - id: mdformat
+        args: [--wrap, "80"]
+        files: '.*\.(md|txt)$'
+
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.48.0
+    hooks:
+      - id: markdownlint
+        language_version: lts
+        args: [--config, .markdownlint-cli]
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.9.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,7 @@ repos:
       - id: mdformat
         args: [--wrap, "80"]
         files: '.*\.(md|txt)$'
+        additional_dependencies: [mdformat-gfm]
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.48.0

--- a/README.md
+++ b/README.md
@@ -1,48 +1,66 @@
 # Triton Extensions
 
-<a href="https://github.com/triton-lang/triton-ext/actions?query=workflow%3ACI"><img src="https://github.com/triton-lang/triton-ext/workflows/CI/badge.svg" alt="build status" /></a>
-<a href="https://discord.com/channels/1189498204333543425/1483539998702567587"><img src="https://img.shields.io/badge/discord-join_chat-blue.svg" alt="discord chat" /></a>
+<a href="https://github.com/triton-lang/triton-ext/actions?query=workflow%3ACI">
+   <!-- markdownlint-disable MD013 -->
+   <img src="https://github.com/triton-lang/triton-ext/workflows/CI/badge.svg" alt="build status" />
+</a>
+<a href="https://discord.com/channels/1189498204333543425/1483539998702567587">
+   <img src="https://img.shields.io/badge/discord-join_chat-blue.svg" alt="discord chat" />
+    <!-- markdownlint-enable MD013 -->
+</a>
 
+A collection of out-of-tree extensions for the Triton compiler, including
+passes, dialects, backends, and language extensions.
 
-
-A collection of out-of-tree extensions for the Triton compiler, including passes, dialects, backends, and language extensions.
-
-> NOTE: this project is *under construction*. It is currently in the early stages of development and parts of it will
-> likely change. Contributions are welcome but be aware that the foundations may change rapidly.
+> NOTE: this project is *under construction*. It is currently in the early
+> stages of development and parts of it will likely change. Contributions are
+> welcome but be aware that the foundations may change rapidly.
 
 ## Overview
 
-This repository provides a framework for developing and building Triton compiler extensions that can extend
-functionality without modifying the core Triton codebase. Extensions are built as shared libraries that can be
-dynamically loaded by Triton at runtime.
+This repository provides a framework for developing and building Triton compiler
+extensions that can extend functionality without modifying the core Triton
+codebase. Extensions are built as shared libraries that can be dynamically
+loaded by Triton at runtime.
 
-Extensions are built on top of the upstream Triton infrastructure documented here:
-https://github.com/triton-lang/triton/tree/main/examples/plugins
+Extensions are built on top of the Triton plugin infrastructure documented
+[upstream](https://github.com/triton-lang/triton/tree/main/examples/plugins).
 
 Slides from the January 2026 Triton Community Meetup:
 [Triton Community Meetup: Triton Extensions Jan 2026](https://docs.google.com/presentation/d/1dnm8uhvabdwqsQAsaPM7IRpEh2tktQ91E1d40r91n1M/edit?usp=sharing)
+
 ### Structure
 
-Each subdirectory's `CMakeLists.txt` is responsible for building its respective extensions.
+Each subdirectory's `CMakeLists.txt` is responsible for building its respective
+extensions.
 
-- **[`backend/`](./backend/)**: Intended for backend extension implementations (currently scaffolding only).
+- **[`backend/`](./backend/)**: Intended for backend extension implementations
+  (currently scaffolding only).
 
-- **[`dialect/`](./dialect/)**: Intended for custom MLIR dialect extensions (currently scaffolding only).
+- **[`dialect/`](./dialect/)**: Intended for custom MLIR dialect extensions
+  (currently scaffolding only).
 
-- **[`language/`](./language/)**: Intended for language extension implementations (currently scaffolding only).
+- **[`language/`](./language/)**: Intended for language extension
+  implementations (currently scaffolding only).
 
-- **[`pass/`](./pass/)**: Contains MLIR pass extensions. Each pass extension is implemented as a shared library that can
-  be loaded dynamically. Pass extensions include a `triton-ext.conf` file that specifies the extension name and status.
+- **[`pass/`](./pass/)**: Contains MLIR pass extensions. Each pass extension is
+  implemented as a shared library that can be loaded dynamically. Pass
+  extensions include a `triton-ext.conf` file that specifies the extension name
+  and status.
 
-- **[`extensions/`](./extensions/)**: Contains standalone plugin extensions that bundle dialects, passes, and language
-  bindings into self-contained shared libraries loadable by Triton at runtime.
+- **[`extensions/`](./extensions/)**: Contains standalone plugin extensions that
+  bundle dialects, passes, and language bindings into self-contained shared
+  libraries loadable by Triton at runtime.
 
-  - **[`utlx` (µTLX)](./extensions/utlx/)**: Triton Language Extensions plugin that provides most of Meta's TLX
-    functionality without modifying the Triton fork. Includes local memory operations (`local_alloc`, `local_view`,
-    `local_store`, `local_load`, `alloc_barriers`), custom passes (e.g., PingPong, PruneUnusedBarriers), the TLX
-    dialect, conversion patterns, and a Python DSL. Builds `libutlx.so`.
+  - **[`utlx` (µTLX)](./extensions/utlx/)**: Triton Language Extensions plugin
+    that provides most of Meta's TLX functionality without modifying the Triton
+    fork. Includes local memory operations (`local_alloc`, `local_view`,
+    `local_store`, `local_load`, `alloc_barriers`), custom passes (e.g.,
+    PingPong, PruneUnusedBarriers), the TLX dialect, conversion patterns, and a
+    Python DSL. Builds `libutlx.so`.
 
-- **[`support/`](./support/)**: Contains extension infrastructure code to automatically register extensions with Triton.
+- **[`support/`](./support/)**: Contains extension infrastructure code to
+  automatically register extensions with Triton.
 
 ## Prerequisites
 
@@ -54,19 +72,21 @@ Note: Extensions are enabled by default in Triton releases 3.7 and beyond.
 
 ## Build
 
-This extension repository is designed to be built out-of-tree. It expects to be pointed to both LLVM
-(`LLVM_INSTALL_DIR`) and Triton (`TRITON_INSTALL_DIR`). Both directories should be installation directories, i.e.,
-built and then packaged with `make install`.
+This extension repository is designed to be built out-of-tree. It expects to be
+pointed to both LLVM (`LLVM_INSTALL_DIR`) and Triton (`TRITON_INSTALL_DIR`).
+Both directories should be installation directories, i.e., built and then
+packaged with `make install`.
 
 To build the extensions:
 
-1. **Build LLVM**: Build LLVM as shared libraries and install it to a known location; see the CI
-   [action](./.github/actions/build-llvm/action.yml) for reference.
+1. **Build LLVM**: Build LLVM as shared libraries and install it to a known
+   location; see the CI [action](./.github/actions/build-llvm/action.yml) for
+   reference.
 
-2. **Build Triton**: Build Triton and install it to a known location; see the CI
+1. **Build Triton**: Build Triton and install it to a known location; see the CI
    [action](./.github/actions/build-triton/action.yml) for reference.
 
-3. **Configure and build extensions**:
+1. **Configure and build extensions**:
 
    ```bash
    mkdir build
@@ -76,12 +96,13 @@ To build the extensions:
    cmake --build build
    ```
 
-   See the CI [workflow](./.github/workflows/ci.yml) for reference. Extensions are built as shared libraries under
-   `build/lib`.
+   See the CI [workflow](./.github/workflows/ci.yml) for reference. Extensions
+   are built as shared libraries under `build/lib`.
 
 ## Use
 
-Pass extensions can be loaded by Triton at runtime using the `TRITON_PASS_PLUGIN_PATH` environment variable (see
+Pass extensions can be loaded by Triton at runtime using the
+`TRITON_PASS_PLUGIN_PATH` environment variable (see
 [Triton plugins](https://github.com/triton-lang/triton/tree/main/examples/plugins)):
 
 ```bash
@@ -91,8 +112,9 @@ python your_script.py
 
 ### Extension Plugins (µTLX)
 
-Extension plugins are loaded via `TRITON_PLUGIN_PATHS`. The µTLX plugin automatically registers itself as
-`triton.language.extra.tlx` when imported, so no filesystem symlinks are needed:
+Extension plugins are loaded via `TRITON_PLUGIN_PATHS`. The µTLX plugin
+automatically registers itself as `triton.language.extra.tlx` when imported, so
+no filesystem symlinks are needed:
 
 ```bash
 export TRITON_PLUGIN_PATHS=/path/to/triton-ext/build/lib/libutlx.so

--- a/extensions/utlx/README.md
+++ b/extensions/utlx/README.md
@@ -1,16 +1,18 @@
 # µTLX: Triton Language Extensions distributed as a Plugin
 
-This package provides most of the function that Meta's TLX (https://github.com/facebookexperimental/triton) does, but without any changes to a fork of Triton.
-
+This package provides most of the function that Meta's [TLX] does, but without
+any changes to a fork of Triton.
 
 ## Create a Project Root Directory
-```
+
+```bash
 mkdir TRITON-uTLX
 export PROJECT_ROOT=`pwd`/TRITON-uTLX
 ```
 
 ## Build a plugable Triton
-```
+
+```bash
 cd $PROJECT_ROOT
 git clone https://github.com/triton-lang/triton.git
 
@@ -20,7 +22,8 @@ TRITON_EXT_ENABLED=1 make -C triton dev-install-llvm
 ```
 
 ## Configure and Build the µTLX plugin
-```
+
+```bash
 cd $PROJECT_ROOT
 git clone -b tlx https://github.com/triton-lang/triton-ext
 
@@ -40,24 +43,31 @@ ninja -C ./triton-ext/extensions/utlx/build
 To use it:
 
 ## Set the plugin path
-```
+
+```bash
 export TRITON_PLUGIN_PATHS=$PROJECT_ROOT/triton-ext/extensions/utlx/build/lib/libutlx.so
 ```
 
-## Run AMD Group GEMM:
+## Run AMD Group GEMM
 
-```
+```bash
 TRITON_PLUGIN_PATHS=$PROJECT_ROOT/triton-ext/extensions/utlx/build/lib/libutlx.so \
 python $PROJECT_ROOT/triton-ext/extensions/utlx/tlx/tutorials/amd-gemm-pipelined_test.py
 ```
 
 ## Run tests
-```
+
+```bash
 cd $PROJECT_ROOT/triton-ext/extensions/utlx/test
 TRITON_PLUGIN_PATHS=$PROJECT_ROOT/triton-ext/extensions/utlx/build/lib/libutlx.so python -m pytest -v
 ```
 
 The three required paths:
+
 - TRITON_SOURCE_DIR — Triton source tree (for headers)
-- TRITON_BUILD_DIR — Triton build directory (for libtriton.so and generated headers)
-- LLVM_BUILD_DIR — LLVM/MLIR build directory (for mlir-tblgen, MLIR libs, and headers)
+- TRITON_BUILD_DIR — Triton build directory (for libtriton.so and generated
+  headers)
+- LLVM_BUILD_DIR — LLVM/MLIR build directory (for mlir-tblgen, MLIR libs, and
+  headers)
+
+[tlx]: https://github.com/facebookexperimental/triton

--- a/extensions/utlx/tlx/README.md
+++ b/extensions/utlx/tlx/README.md
@@ -2,19 +2,27 @@
 
 ## Introduction
 
-TLX (Triton Low-level Language Extensions) is a low-level, warp-aware, hardware-near extension of the Triton DSL. It provides intrinsics and warp-specialized operations for fine-grained GPU control, hardware-oriented primitives for advanced kernel development, and explicit constructs for GPU memory, compute, and asynchronous control flow, designed for power users pushing Triton to the metal.
+TLX (Triton Low-level Language Extensions) is a low-level, warp-aware,
+hardware-near extension of the Triton DSL. It provides intrinsics and
+warp-specialized operations for fine-grained GPU control, hardware-oriented
+primitives for advanced kernel development, and explicit constructs for GPU
+memory, compute, and asynchronous control flow, designed for power users pushing
+Triton to the metal.
 
 ## Memory Fences
 
 `tlx.fence(scope)` issues a memory fence. The `scope` argument is required:
 
-| Scope | PTX | Description |
-|-------|-----|-------------|
-| `"gpu"` | `fence.acq_rel.gpu` | Device-scope fence. Orders prior global/shared memory writes to be visible to all GPU threads. |
-| `"sys"` | `fence.acq_rel.sys` | System-scope fence. Like `"gpu"` but also visible to the host CPU. |
-| `"async_shared"` | `fence.proxy.async.shared::cta` | Proxy fence for async shared memory. Required between `local_store` and a subsequent TMA store (`async_descriptor_store`) to the same shared memory. |
+| Scope | PTX | Description | |-------|-----|-------------| | `"gpu"` |
+`fence.acq_rel.gpu` | Device-scope fence. Orders prior global/shared memory
+writes to be visible to all GPU threads. | | `"sys"` | `fence.acq_rel.sys` |
+System-scope fence. Like `"gpu"` but also visible to the host CPU. | |
+`"async_shared"` | `fence.proxy.async.shared::cta` | Proxy fence for async
+shared memory. Required between `local_store` and a subsequent TMA store
+(`async_descriptor_store`) to the same shared memory. |
 
 Example:
+
 ```python
 tlx.local_store(smem_buf, data)
 tlx.fence("async_shared")

--- a/extensions/utlx/tlx/README.md
+++ b/extensions/utlx/tlx/README.md
@@ -13,13 +13,11 @@ Triton to the metal.
 
 `tlx.fence(scope)` issues a memory fence. The `scope` argument is required:
 
-| Scope | PTX | Description | |-------|-----|-------------| | `"gpu"` |
-`fence.acq_rel.gpu` | Device-scope fence. Orders prior global/shared memory
-writes to be visible to all GPU threads. | | `"sys"` | `fence.acq_rel.sys` |
-System-scope fence. Like `"gpu"` but also visible to the host CPU. | |
-`"async_shared"` | `fence.proxy.async.shared::cta` | Proxy fence for async
-shared memory. Required between `local_store` and a subsequent TMA store
-(`async_descriptor_store`) to the same shared memory. |
+| Scope            | PTX                             | Description                                                                                                                                          |
+| ---------------- | ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `"gpu"`          | `fence.acq_rel.gpu`             | Device-scope fence. Orders prior global/shared memory writes to be visible to all GPU threads.                                                       |
+| `"sys"`          | `fence.acq_rel.sys`             | System-scope fence. Like `"gpu"` but also visible to the host CPU.                                                                                   |
+| `"async_shared"` | `fence.proxy.async.shared::cta` | Proxy fence for async shared memory. Required between `local_store` and a subsequent TMA store (`async_descriptor_store`) to the same shared memory. |
 
 Example:
 

--- a/extensions/utlx/tlx/doc/PlaceholderLayouts.md
+++ b/extensions/utlx/tlx/doc/PlaceholderLayouts.md
@@ -53,9 +53,9 @@ ______________________________________________________________________
 
 We define one placeholder layout types, organized by memory space and use case:
 
-| Placeholder Type | Memory Space | Resolves To |
-|------------------|--------------|-------------| | `DummyRegisterLayoutAttr` |
-Registers | `BlockedEncodingAttr` |
+| Placeholder Type          | Memory Space | Resolves To           |
+| ------------------------- | ------------ | --------------------- |
+| `DummyRegisterLayoutAttr` | Registers    | `BlockedEncodingAttr` |
 
 ### IR Examples
 
@@ -108,10 +108,9 @@ passes.ttir.add_rewrite_tensor_pointer(pm)
 
 Each placeholder type has a dedicated resolution function:
 
-| Placeholder | Resolution Function | Key Parameters Used |
-|-------------|---------------------|---------------------| |
-`DummyRegisterLayoutAttr` | `resolveRegisterLayout()` | shape, numWarps,
-threadsPerWarp, numCTAs |
+| Placeholder               | Resolution Function       | Key Parameters Used                      |
+| ------------------------- | ------------------------- | ---------------------------------------- |
+| `DummyRegisterLayoutAttr` | `resolveRegisterLayout()` | shape, numWarps, threadsPerWarp, numCTAs |
 
 The resolution functions use `ttg::lookupNumWarps()` and similar utilities to
 obtain the correct context-dependent values after inlining.
@@ -136,11 +135,12 @@ ______________________________________________________________________
 
 ## File Summary
 
-| File | Purpose | |------|---------| | `language/tlx/types.py` | Python
-placeholder layout classes | | `language/tlx/__init__.py` | Exports placeholder
-layout classes | | `dialect/include/IR/TLXAttrDefs.td` | TableGen definitions
-for placeholder attributes | | `dialect/triton_tlx.cc` | C++ builder methods for
-creating placeholder attributes | |
-`dialect/lib/Transforms/ResolvePlaceholderLayouts.cpp` | Resolution pass
-implementation | | `dialect/include/Transforms/Passes.td` | Pass declaration | |
-`nvidia/backend/compiler.py` | Pipeline integration |
+| File                                                   | Purpose                                                 |
+| ------------------------------------------------------ | ------------------------------------------------------- |
+| `language/tlx/types.py`                                | Python placeholder layout classes                       |
+| `language/tlx/__init__.py`                             | Exports placeholder layout classes                      |
+| `dialect/include/IR/TLXAttrDefs.td`                    | TableGen definitions for placeholder attributes         |
+| `dialect/triton_tlx.cc`                                | C++ builder methods for creating placeholder attributes |
+| `dialect/lib/Transforms/ResolvePlaceholderLayouts.cpp` | Resolution pass implementation                          |
+| `dialect/include/Transforms/Passes.td`                 | Pass declaration                                        |
+| `nvidia/backend/compiler.py`                           | Pipeline integration                                    |

--- a/extensions/utlx/tlx/doc/PlaceholderLayouts.md
+++ b/extensions/utlx/tlx/doc/PlaceholderLayouts.md
@@ -2,65 +2,85 @@
 
 ## Motivating Problem
 
-In Triton, layout encodings (such as `BlockedEncodingAttr`, `NvidiaMmaEncodingAttr`, `DotOperandEncodingAttr`, etc.) determine how tensor data is distributed across threads, warps, and CTAs. Many of these layouts depend on the **number of warps** (`num_warps`) to compute the correct distribution.
+In Triton, layout encodings (such as `BlockedEncodingAttr`,
+`NvidiaMmaEncodingAttr`, `DotOperandEncodingAttr`, etc.) determine how tensor
+data is distributed across threads, warps, and CTAs. Many of these layouts
+depend on the **number of warps** (`num_warps`) to compute the correct
+distribution.
 
-A critical issue arises when TLX functions are defined separately from their call sites:
+A critical issue arises when TLX functions are defined separately from their
+call sites:
 
-1. **Separate function definition**: When a TLX kernel helper is written as a separate function, any layout computation during lowering sees the **global module's `num_warps`**.
+1. **Separate function definition**: When a TLX kernel helper is written as a
+   separate function, any layout computation during lowering sees the **global
+   module's `num_warps`**.
 
-2. **Inlined context**: After function inlining, the same code may execute in a different context (e.g., inside a `tlx.async_task` region) where the **effective `num_warps` is different** from the global value.
+1. **Inlined context**: After function inlining, the same code may execute in a
+   different context (e.g., inside a `tlx.async_task` region) where the
+   **effective `num_warps` is different** from the global value.
 
 This mismatch causes incorrect or inconsistent layouts. For example:
+
 - A function lowered with `num_warps=4` at the global level
 - Gets inlined into an `async_task` that executes with `num_warps=2`
 - The pre-computed layout is now wrong for the actual execution context
 
-**Solution**: We use **placeholder (dummy) layouts** during initial lowering that defer the actual layout computation until after function inlining. A dedicated pass (`TLXResolvePlaceholderLayouts`) then resolves these placeholders to concrete layouts when the correct `num_warps` and other context information is available.
+**Solution**: We use **placeholder (dummy) layouts** during initial lowering
+that defer the actual layout computation until after function inlining. A
+dedicated pass (`TLXResolvePlaceholderLayouts`) then resolves these placeholders
+to concrete layouts when the correct `num_warps` and other context information
+is available.
 
-Right now we have only implemented the placeholder layouts for TMEM dependent layouts, which is the requirement for Flash Attention Backwards.
+Right now we have only implemented the placeholder layouts for TMEM dependent
+layouts, which is the requirement for Flash Attention Backwards.
 
----
+______________________________________________________________________
 
 ## Overview
 
 The placeholder layout system consists of three components:
 
-1. **Placeholder Layout Attributes**: MLIR attributes that carry shape and type information but defer concrete layout decisions
-2. **Python Encoding Classes**: Frontend classes that generate placeholder layout attributes during lowering
-3. **Resolution Pass**: A C++ pass that replaces placeholder layouts with concrete layouts after inlining
+1. **Placeholder Layout Attributes**: MLIR attributes that carry shape and type
+   information but defer concrete layout decisions
+1. **Python Encoding Classes**: Frontend classes that generate placeholder
+   layout attributes during lowering
+1. **Resolution Pass**: A C++ pass that replaces placeholder layouts with
+   concrete layouts after inlining
 
----
+______________________________________________________________________
 
 ## Placeholder Layout Types
 
 We define one placeholder layout types, organized by memory space and use case:
 
 | Placeholder Type | Memory Space | Resolves To |
-|------------------|--------------|-------------|
-| `DummyRegisterLayoutAttr` | Registers | `BlockedEncodingAttr` |
-
+|------------------|--------------|-------------| | `DummyRegisterLayoutAttr` |
+Registers | `BlockedEncodingAttr` |
 
 ### IR Examples
 
 **Before resolution:**
+
 ```mlir
 // Register tensor with placeholder layout
 %0 = tlx.require_layout %arg : tensor<128x64xf16, #tlx.dummy_register_layout<[128, 64], f16>>
 ```
 
 **After resolution:**
+
 ```mlir
 // Register resolved to Blocked encoding
 %0 = tlx.require_layout %arg : tensor<128x64xf16, #ttg.blocked<...>>
 ```
 
----
+______________________________________________________________________
 
 ## Python Frontend Classes
 
 The following Python classes generate placeholder layouts during lowering:
 
 ### DummyRegisterLayoutEncoding
+
 ```python
 class DummyRegisterLayoutEncoding(layout_encoding):
     def __init__(self, shape: List[int], element_type: tl.dtype):
@@ -68,11 +88,12 @@ class DummyRegisterLayoutEncoding(layout_encoding):
         self.element_type = element_type
 ```
 
----
+______________________________________________________________________
 
 ## Resolution Pass
 
-The `TLXResolvePlaceholderLayouts` pass runs after function inlining and resolves all placeholder layouts to concrete layouts.
+The `TLXResolvePlaceholderLayouts` pass runs after function inlining and
+resolves all placeholder layouts to concrete layouts.
 
 ### Pipeline Location
 
@@ -88,12 +109,14 @@ passes.ttir.add_rewrite_tensor_pointer(pm)
 Each placeholder type has a dedicated resolution function:
 
 | Placeholder | Resolution Function | Key Parameters Used |
-|-------------|---------------------|---------------------|
-| `DummyRegisterLayoutAttr` | `resolveRegisterLayout()` | shape, numWarps, threadsPerWarp, numCTAs |
+|-------------|---------------------|---------------------| |
+`DummyRegisterLayoutAttr` | `resolveRegisterLayout()` | shape, numWarps,
+threadsPerWarp, numCTAs |
 
-The resolution functions use `ttg::lookupNumWarps()` and similar utilities to obtain the correct context-dependent values after inlining.
+The resolution functions use `ttg::lookupNumWarps()` and similar utilities to
+obtain the correct context-dependent values after inlining.
 
----
+______________________________________________________________________
 
 ## TableGen Definitions
 
@@ -109,16 +132,15 @@ def TLX_DummyRegisterLayoutAttr : TLX_Attr<"DummyRegisterLayout", []> {
 }
 ```
 
----
+______________________________________________________________________
 
 ## File Summary
 
-| File | Purpose |
-|------|---------|
-| `language/tlx/types.py` | Python placeholder layout classes |
-| `language/tlx/__init__.py` | Exports placeholder layout classes |
-| `dialect/include/IR/TLXAttrDefs.td` | TableGen definitions for placeholder attributes |
-| `dialect/triton_tlx.cc` | C++ builder methods for creating placeholder attributes |
-| `dialect/lib/Transforms/ResolvePlaceholderLayouts.cpp` | Resolution pass implementation |
-| `dialect/include/Transforms/Passes.td` | Pass declaration |
-| `nvidia/backend/compiler.py` | Pipeline integration |
+| File | Purpose | |------|---------| | `language/tlx/types.py` | Python
+placeholder layout classes | | `language/tlx/__init__.py` | Exports placeholder
+layout classes | | `dialect/include/IR/TLXAttrDefs.td` | TableGen definitions
+for placeholder attributes | | `dialect/triton_tlx.cc` | C++ builder methods for
+creating placeholder attributes | |
+`dialect/lib/Transforms/ResolvePlaceholderLayouts.cpp` | Resolution pass
+implementation | | `dialect/include/Transforms/Passes.td` | Pass declaration | |
+`nvidia/backend/compiler.py` | Pipeline integration |

--- a/extensions/utlx/tlx/doc/StorageAliasSpecAndSetBufferOverlap.md
+++ b/extensions/utlx/tlx/doc/StorageAliasSpecAndSetBufferOverlap.md
@@ -1,29 +1,47 @@
 # TLX `storage_alias_spec` and `set_buffer_overlap` Design
 
-**Author:** Nick Riasanovsky
-**Updated:** 2026-02-12
+**Author:** Nick Riasanovsky **Updated:** 2026-02-12
 
----
+______________________________________________________________________
 
 ## Background
 
-In Blackwell kernels there is often a need to share buffer memory between multiple allocations to allow sufficiently large block sizes for performance. Previously, this was done through the `local_alloc` API via the `reuse` parameter, which accepted an existing `buffered_tensor`. This approach required manual memory management — users had to calculate buffer counts, padding, and offsets themselves — which led to several problems:
+In Blackwell kernels there is often a need to share buffer memory between
+multiple allocations to allow sufficiently large block sizes for performance.
+Previously, this was done through the `local_alloc` API via the `reuse`
+parameter, which accepted an existing `buffered_tensor`. This approach required
+manual memory management — users had to calculate buffer counts, padding, and
+offsets themselves — which led to several problems:
 
-1. **Error-prone indexing**: Users must specify an exact number of buffers to get sufficient isolation. When anything changes (e.g. datatype, blocksize) the number of buffers and their overlap relationships change. Users must manually update all index calculations, which is a source of subtle bugs.
-2. **Implicit primary ownership**: The original `reuse` API made one allocation the "primary owner" of the buffer. All other allocations had to be smaller, creating asymmetry and requiring careful ordering.
-3. **Autotuning limitations**: Due to issue 1 it can be difficult to exhaustively autotune, likely leaving performance on the table.
+1. **Error-prone indexing**: Users must specify an exact number of buffers to
+   get sufficient isolation. When anything changes (e.g. datatype, blocksize)
+   the number of buffers and their overlap relationships change. Users must
+   manually update all index calculations, which is a source of subtle bugs.
+1. **Implicit primary ownership**: The original `reuse` API made one allocation
+   the "primary owner" of the buffer. All other allocations had to be smaller,
+   creating asymmetry and requiring careful ordering.
+1. **Autotuning limitations**: Due to issue 1 it can be difficult to
+   exhaustively autotune, likely leaving performance on the table.
 
 ### Motivating Example
 
-In Flash Attention, `qk_tiles` and `p_tiles` need to share the same underlying memory. With the old API, the user had to manually compute the correct number of buffers for `p_tiles` based on the data type ratio (e.g., `NUM_BUFFERS_QK * 2` for BF16 because `sizeof(float32) / sizeof(bfloat16) == 2`). If the data type changed to FP8, the multiplier would change to 4, and all downstream index logic would need to be updated.
+In Flash Attention, `qk_tiles` and `p_tiles` need to share the same underlying
+memory. With the old API, the user had to manually compute the correct number of
+buffers for `p_tiles` based on the data type ratio (e.g., `NUM_BUFFERS_QK * 2`
+for BF16 because `sizeof(float32) / sizeof(bfloat16) == 2`). If the data type
+changed to FP8, the multiplier would change to 4, and all downstream index logic
+would need to be updated.
 
----
+______________________________________________________________________
 
 ## Frontend API
 
 ### `storage_alias_spec`
 
-The `storage_alias_spec` builtin creates a logical specification for a shared buffer region. Unlike the legacy `reuse` approach where one `buffered_tensor` was the primary owner, a `storage_alias_spec` makes all referencing allocations equal peers with no primary owner.
+The `storage_alias_spec` builtin creates a logical specification for a shared
+buffer region. Unlike the legacy `reuse` approach where one `buffered_tensor`
+was the primary owner, a `storage_alias_spec` makes all referencing allocations
+equal peers with no primary owner.
 
 ```python
 def storage_alias_spec(
@@ -33,18 +51,25 @@ def storage_alias_spec(
 ```
 
 **Parameters:**
-- `storage`: The storage kind (`smem` or `tmem`). `smemCluster` is not supported.
-- `buffer_size_bytes`: Optional explicit size in bytes (must be a compile-time constant). If omitted, the compiler computes the size as the maximum across all referencing allocations.
+
+- `storage`: The storage kind (`smem` or `tmem`). `smemCluster` is not
+  supported.
+- `buffer_size_bytes`: Optional explicit size in bytes (must be a compile-time
+  constant). If omitted, the compiler computes the size as the maximum across
+  all referencing allocations.
 
 **Properties (all immutable after construction):**
+
 - `storage`: The storage kind.
 - `buffer_size_bytes`: The explicit size, or `None` if unsized.
 
-**Defined in:** `language/tlx/mem_ops.py` (builtin function), `language/tlx/types.py` (class and type)
+**Defined in:** `language/tlx/mem_ops.py` (builtin function),
+`language/tlx/types.py` (class and type)
 
 ### Updated `local_alloc`
 
-The `local_alloc` function's `reuse` parameter now accepts either a `buffered_tensor` (legacy behavior) or a `storage_alias_spec`:
+The `local_alloc` function's `reuse` parameter now accepts either a
+`buffered_tensor` (legacy behavior) or a `storage_alias_spec`:
 
 ```python
 def local_alloc(
@@ -57,21 +82,29 @@ def local_alloc(
 ) -> tlx.buffered_tensor
 ```
 
-When `reuse` is a `storage_alias_spec`, the frontend emits a `StorageAliasLocalAllocOp` (instead of the standard `LocalAllocOp`). The storage kind of the spec and the `local_alloc` call must match.
+When `reuse` is a `storage_alias_spec`, the frontend emits a
+`StorageAliasLocalAllocOp` (instead of the standard `LocalAllocOp`). The storage
+kind of the spec and the `local_alloc` call must match.
 
 **Defined in:** `language/tlx/mem_ops.py`
 
 ### `reuse_group`
 
-A `reuse_group` defines the overlap relationships between buffers that share a `storage_alias_spec`. It forms a tree structure where:
+A `reuse_group` defines the overlap relationships between buffers that share a
+`storage_alias_spec`. It forms a tree structure where:
 
 - **Leaf nodes** are `buffered_tensor` objects (from `local_alloc`).
 - **Internal nodes** are nested `reuse_group` objects.
 
-Each group has a `group_type` that defines the relationship between its children:
+Each group has a `group_type` that defines the relationship between its
+children:
 
-- **`shared`** (default): Children logically occupy the **same** memory region at each buffer index. This does not mean they must physically overlap — it means the compiler guarantees no cross-index overlap. The user is responsible for synchronization via barriers, but should assume they can overlap.
-- **`distinct`**: Children must be placed in **non-overlapping** memory regions. They can be accessed simultaneously without conflicts.
+- **`shared`** (default): Children logically occupy the **same** memory region
+  at each buffer index. This does not mean they must physically overlap — it
+  means the compiler guarantees no cross-index overlap. The user is responsible
+  for synchronization via barriers, but should assume they can overlap.
+- **`distinct`**: Children must be placed in **non-overlapping** memory regions.
+  They can be accessed simultaneously without conflicts.
 
 ```python
 class reuse_group:
@@ -84,32 +117,44 @@ class reuse_group:
 ```
 
 **Parameters:**
+
 - `*args`: One or more `buffered_tensor` or nested `reuse_group` objects.
 - `group_type`: `shared` or `distinct`.
-- `group_size`: Multiplier for buffer grouping (subtiling). When `group_size > 1`, K consecutive buffers are treated as a single logical group for offset calculation. For example, with `group_size=2` on a tensor with 4 buffers, buffers `[0,1]` form logical group 0 and `[2,3]` form logical group 1. This is
-used when we want to create an unequal number of buffers (for example subtiling P in FA).
+- `group_size`: Multiplier for buffer grouping (subtiling). When
+  `group_size > 1`, K consecutive buffers are treated as a single logical group
+  for offset calculation. For example, with `group_size=2` on a tensor with 4
+  buffers, buffers `[0,1]` form logical group 0 and `[2,3]` form logical group
+  1\. This is used when we want to create an unequal number of buffers (for
+  example subtiling P in FA).
 
 **Defined in:** `language/tlx/types.py`
 
 ### `set_buffer_overlap`
 
-The `set_buffer_overlap` method on `storage_alias_spec` links the spec to its overlap definition. This is called in JIT code (not at construction time) for two reasons:
+The `set_buffer_overlap` method on `storage_alias_spec` links the spec to its
+overlap definition. This is called in JIT code (not at construction time) for
+two reasons:
 
-1. It avoids introducing artificial IDs — the method directly references the allocated `buffered_tensor` objects.
-2. The overlap definition can be conditional on `constexpr` values, enabling different overlap schemes based on block size or other compile-time parameters.
+1. It avoids introducing artificial IDs — the method directly references the
+   allocated `buffered_tensor` objects.
+1. The overlap definition can be conditional on `constexpr` values, enabling
+   different overlap schemes based on block size or other compile-time
+   parameters.
 
 ```python
 class storage_alias_spec:
     def set_buffer_overlap(self, overlap_def: reuse_group) -> None
 ```
 
-The overlap definition must be a `reuse_group` whose leaf nodes are all `buffered_tensor` objects allocated from this `storage_alias_spec`.
+The overlap definition must be a `reuse_group` whose leaf nodes are all
+`buffered_tensor` objects allocated from this `storage_alias_spec`.
 
 **Defined in:** `language/tlx/types.py`
 
 ### Usage Example (Flash Attention)
 
-The following is from the Blackwell Flash Attention pipelined persistent kernel (`tutorials/blackwell_fa_ws_pipelined_persistent.py`):
+The following is from the Blackwell Flash Attention pipelined persistent kernel
+(`tutorials/blackwell_fa_ws_pipelined_persistent.py`):
 
 ```python
 # Create the storage alias spec for all shared buffers
@@ -159,7 +204,7 @@ qk_storage_alias.set_buffer_overlap(
 
 This defines a tree:
 
-```
+```txt
         shared (root)
        /            \
    qk_tiles       distinct
@@ -169,19 +214,24 @@ This defines a tree:
       NUM_MMA_SLICES)
 ```
 
-At each buffer index, `qk_tiles` shares its memory region with the distinct group of `p_tiles`, `alpha`, `l`, and `m`. Within that distinct group, `p_tiles` (with subtiling), `alpha`, `l`, and `m` are placed in non-overlapping regions.
+At each buffer index, `qk_tiles` shares its memory region with the distinct
+group of `p_tiles`, `alpha`, `l`, and `m`. Within that distinct group, `p_tiles`
+(with subtiling), `alpha`, `l`, and `m` are placed in non-overlapping regions.
 
----
+______________________________________________________________________
 
 ## IR Operations
 
-The frontend lowers the Python API into four MLIR operations defined in the TLX dialect.
+The frontend lowers the Python API into four MLIR operations defined in the TLX
+dialect.
 
 ### `tlx.storage_alias_spec`
 
-Creates a storage alias specification. Does not allocate memory itself; it defines a logical grouping for buffer sharing.
+Creates a storage alias specification. Does not allocate memory itself; it
+defines a logical grouping for buffer sharing.
 
-**Arguments:** `storage` (smem or tmem), optional `buffer_size_bytes`, optional `buffer_shape` (set by compiler).
+**Arguments:** `storage` (smem or tmem), optional `buffer_size_bytes`, optional
+`buffer_shape` (set by compiler).
 
 **Result:** `!tlx.storage_alias_spec<storage[, size]>`
 
@@ -189,7 +239,10 @@ Creates a storage alias specification. Does not allocate memory itself; it defin
 
 ### `tlx.storage_alias_local_alloc`
 
-An intermediate allocation operation produced when `local_alloc` is called with a `storage_alias_spec`. It references the spec and produces a `!ttg.memdesc` result. After the storage alias lowering pass, this operation is replaced with a `tlx.local_alias` pointing to a standard allocation.
+An intermediate allocation operation produced when `local_alloc` is called with
+a `storage_alias_spec`. It references the spec and produces a `!ttg.memdesc`
+result. After the storage alias lowering pass, this operation is replaced with a
+`tlx.local_alias` pointing to a standard allocation.
 
 **Arguments:** `storage_alias` (`!tlx.storage_alias_spec`)
 
@@ -199,9 +252,12 @@ An intermediate allocation operation produced when `local_alloc` is called with 
 
 ### `tlx.reuse_group`
 
-Creates a reuse group tree node. Accepts a variadic list of elements (either `!ttg.memdesc` or `!tlx.reuse_group`) and produces a `!tlx.reuse_group<kind>` result.
+Creates a reuse group tree node. Accepts a variadic list of elements (either
+`!ttg.memdesc` or `!tlx.reuse_group`) and produces a `!tlx.reuse_group<kind>`
+result.
 
-**Arguments:** `elements` (variadic), `group_kind` (shared or distinct), `group_size` (default 1).
+**Arguments:** `elements` (variadic), `group_kind` (shared or distinct),
+`group_size` (default 1).
 
 **Result:** `!tlx.reuse_group<kind>`
 
@@ -209,7 +265,8 @@ Creates a reuse group tree node. Accepts a variadic list of elements (either `!t
 
 ### `set_buffer_overlap`
 
-Links a `storage_alias_spec` to its overlap definition (a `reuse_group`). This operation is consumed and erased during the buffer offset calculation pass.
+Links a `storage_alias_spec` to its overlap definition (a `reuse_group`). This
+operation is consumed and erased during the buffer offset calculation pass.
 
 **Arguments:** `storage_alias_spec`, `overlap_def` (`!tlx.reuse_group`)
 
@@ -217,7 +274,10 @@ Links a `storage_alias_spec` to its overlap definition (a `reuse_group`). This o
 
 ### `tlx.local_alias`
 
-Creates an alias of a local memory buffer with a different view (shape, element type, or encoding). Produced during the storage alias allocation pass when lowering `StorageAliasLocalAllocOp`. This is the final form — each `local_alias` points to the single backing allocation created for the `storage_alias_spec`.
+Creates an alias of a local memory buffer with a different view (shape, element
+type, or encoding). Produced during the storage alias allocation pass when
+lowering `StorageAliasLocalAllocOp`. This is the final form — each `local_alias`
+points to the single backing allocation created for the `storage_alias_spec`.
 
 **Defined in:** `dialect/include/IR/TLXOps.td` (`TLX_LocalAliasOp`)
 
@@ -225,53 +285,90 @@ Creates an alias of a local memory buffer with a different view (shape, element 
 
 Two custom MLIR types support the operations:
 
-- **`!tlx.storage_alias_spec<storage[, size]>`**: Carries the storage kind and optional explicit size. Defined in `dialect/include/IR/TLXTypes.td`.
-- **`!tlx.reuse_group<kind>`**: Carries the group kind (shared or distinct). Defined in `dialect/include/IR/TLXTypes.td`.
+- **`!tlx.storage_alias_spec<storage[, size]>`**: Carries the storage kind and
+  optional explicit size. Defined in `dialect/include/IR/TLXTypes.td`.
+- **`!tlx.reuse_group<kind>`**: Carries the group kind (shared or distinct).
+  Defined in `dialect/include/IR/TLXTypes.td`.
 
----
+______________________________________________________________________
 
 ## Compiler Pass Pipeline
 
-The storage alias lowering is orchestrated by a single combined pass (`TLXStorageAliasLoweringPass`) that executes three steps sequentially. The ordering is critical: size definition must precede offset calculation, and offset calculation must precede allocation materialization (because materialization erases the ops that the earlier steps depend on).
+The storage alias lowering is orchestrated by a single combined pass
+(`TLXStorageAliasLoweringPass`) that executes three steps sequentially. The
+ordering is critical: size definition must precede offset calculation, and
+offset calculation must precede allocation materialization (because
+materialization erases the ops that the earlier steps depend on).
 
 ### Step 1: Storage Alias Size Definition
 
 **Purpose:** Compute or validate the buffer size for each `storage_alias_spec`.
 
 **Logic:**
-- Collects all `StorageAliasLocalAllocOp` operations and groups them by their referenced `storage_alias_spec`.
-- For **SMEM**: If a `SetBufferOverlapOp` exists, the reuse group tree is walked to compute the size per buffer. The tree semantics are: `shared` → max of children (multiplied by `group_size`), `distinct` → sum of children. Otherwise, the size is the maximum across all referencing allocations.
-- For **TMEM**: Computes a 2D shape (blockM × blockN) based on the maximum dimensions across all users, with scaling for element size relative to i32 (4 bytes). blockM is constrained to 64 or 128 for TMEM hardware requirements.
-- If `buffer_size_bytes` was explicitly set by the user, validates that it is large enough. Otherwise, sets it to the computed value.
-- Sets the `buffer_shape` attribute on the `StorageAliasSpecOp` for use by subsequent passes.
+
+- Collects all `StorageAliasLocalAllocOp` operations and groups them by their
+  referenced `storage_alias_spec`.
+- For **SMEM**: If a `SetBufferOverlapOp` exists, the reuse group tree is walked
+  to compute the size per buffer. The tree semantics are: `shared` → max of
+  children (multiplied by `group_size`), `distinct` → sum of children.
+  Otherwise, the size is the maximum across all referencing allocations.
+- For **TMEM**: Computes a 2D shape (blockM × blockN) based on the maximum
+  dimensions across all users, with scaling for element size relative to i32 (4
+  bytes). blockM is constrained to 64 or 128 for TMEM hardware requirements.
+- If `buffer_size_bytes` was explicitly set by the user, validates that it is
+  large enough. Otherwise, sets it to the computed value.
+- Sets the `buffer_shape` attribute on the `StorageAliasSpecOp` for use by
+  subsequent passes.
 
 **Defined in:** `dialect/lib/Transforms/StorageAliasSizeDefinition.cpp`
 
 ### Step 2: Buffer Offset Calculation
 
-**Purpose:** Compute the memory offset for each allocation based on the reuse group tree defined by `set_buffer_overlap`.
+**Purpose:** Compute the memory offset for each allocation based on the reuse
+group tree defined by `set_buffer_overlap`.
 
 **Logic:**
+
 - Collects all `SetBufferOverlapOp` operations.
 - For each, recursively walks the reuse group tree starting at offset 0:
-  - **`shared`**: All children start at the same offset. The `bytesBetweenBufferGroups` is divided by `group_size` for subtiling, and the effective `group_size` is multiplied down to children.
-  - **`distinct`**: Children are placed sequentially — each child's offset is the previous child's offset plus its size. Validates that the total does not exceed available space.
-- Produces an `offsetMap` mapping each `StorageAliasLocalAllocOp` result to a tuple of `(buffer_offset, bytes_between_buffer_groups, group_size)`.
-- Erases the `SetBufferOverlapOp` and cleans up unused `ReuseGroupOp` operations.
+  - **`shared`**: All children start at the same offset. The
+    `bytesBetweenBufferGroups` is divided by `group_size` for subtiling, and the
+    effective `group_size` is multiplied down to children.
+  - **`distinct`**: Children are placed sequentially — each child's offset is
+    the previous child's offset plus its size. Validates that the total does not
+    exceed available space.
+- Produces an `offsetMap` mapping each `StorageAliasLocalAllocOp` result to a
+  tuple of `(buffer_offset, bytes_between_buffer_groups, group_size)`.
+- Erases the `SetBufferOverlapOp` and cleans up unused `ReuseGroupOp`
+  operations.
 
 **Defined in:** `dialect/lib/Transforms/BufferOffsetCalculation.cpp`
 
 ### Step 3: Storage Alias Allocation
 
-**Purpose:** Materialize the actual memory allocations and replace intermediate ops with standard TritonGPU IR.
+**Purpose:** Materialize the actual memory allocations and replace intermediate
+ops with standard TritonGPU IR.
 
 **Logic:**
-1. **Create backing allocations**: For each `StorageAliasSpecOp`, creates a single `LocalAllocOp` (SMEM, 1D byte buffer) or `TMEMAllocOp` (TMEM, 2D i32 buffer) with the computed shape.
-2. **Replace intermediate ops**: Each `StorageAliasLocalAllocOp` is replaced with a `LocalAliasOp` pointing to the backing allocation. If offset information exists from Step 2, the alias type's shape may be expanded to accommodate the offset/scale transformations.
-3. **Rewrite index operations**: When an allocation has non-trivial offsets (from `set_buffer_overlap`), all `MemDescIndexOp` users are rewritten with the transformation: `newIndex = scaleFactor * originalIndex + offsetSlots + (originalIndex % groupSize)`. This correctly maps logical buffer indices to physical positions in the expanded buffer, accounting for both offset placement and subtiling.
-4. **Clean up**: Erases all `StorageAliasSpecOp` operations.
 
-The pass also handles propagation through `MemDescReinterpretOp`, nested `LocalAliasOp`, and `WarpSpecializeOp` captures (updating block argument types in partition regions when the aliased type changes).
+1. **Create backing allocations**: For each `StorageAliasSpecOp`, creates a
+   single `LocalAllocOp` (SMEM, 1D byte buffer) or `TMEMAllocOp` (TMEM, 2D i32
+   buffer) with the computed shape.
+1. **Replace intermediate ops**: Each `StorageAliasLocalAllocOp` is replaced
+   with a `LocalAliasOp` pointing to the backing allocation. If offset
+   information exists from Step 2, the alias type's shape may be expanded to
+   accommodate the offset/scale transformations.
+1. **Rewrite index operations**: When an allocation has non-trivial offsets
+   (from `set_buffer_overlap`), all `MemDescIndexOp` users are rewritten with
+   the transformation:
+   `newIndex = scaleFactor * originalIndex + offsetSlots + (originalIndex % groupSize)`.
+   This correctly maps logical buffer indices to physical positions in the
+   expanded buffer, accounting for both offset placement and subtiling.
+1. **Clean up**: Erases all `StorageAliasSpecOp` operations.
+
+The pass also handles propagation through `MemDescReinterpretOp`, nested
+`LocalAliasOp`, and `WarpSpecializeOp` captures (updating block argument types
+in partition regions when the aliased type changes).
 
 **Defined in:** `dialect/lib/Transforms/StorageAliasAllocation.cpp`
 
@@ -279,117 +376,152 @@ The pass also handles propagation through `MemDescReinterpretOp`, nested `LocalA
 
 **Defined in:** `dialect/lib/Transforms/StorageAliasLowering.cpp`
 
-The `TLXStorageAliasLoweringPass` calls the three steps in order, failing the pass if any step returns an error.
+The `TLXStorageAliasLoweringPass` calls the three steps in order, failing the
+pass if any step returns an error.
 
----
+______________________________________________________________________
 
 ## Compiler Safety Guarantees
 
-A key goal of this design is to produce **static compilation errors** when the overlap scheme cannot be achieved, rather than silently generating incorrect kernels:
+A key goal of this design is to produce **static compilation errors** when the
+overlap scheme cannot be achieved, rather than silently generating incorrect
+kernels:
 
-- **Size validation**: If `buffer_size_bytes` is explicitly specified and is too small for the computed requirements, the compiler emits an error.
-- **Distinct group overflow**: If the children of a `distinct` group require more space than is available within `bytesBetweenBufferGroups`, the compiler emits an error.
-- **Offset alignment**: If `buffer_offset` or `bytes_between_buffer_groups` is not a multiple of the per-buffer allocation size, the compiler emits an error.
-- **Duplicate overlap definitions**: If `set_buffer_overlap` is called more than once on the same spec, the compiler emits an error.
-- **Unused specs**: If a `storage_alias_spec` has no referencing allocations, the compiler emits a warning.
+- **Size validation**: If `buffer_size_bytes` is explicitly specified and is too
+  small for the computed requirements, the compiler emits an error.
+- **Distinct group overflow**: If the children of a `distinct` group require
+  more space than is available within `bytesBetweenBufferGroups`, the compiler
+  emits an error.
+- **Offset alignment**: If `buffer_offset` or `bytes_between_buffer_groups` is
+  not a multiple of the per-buffer allocation size, the compiler emits an error.
+- **Duplicate overlap definitions**: If `set_buffer_overlap` is called more than
+  once on the same spec, the compiler emits an error.
+- **Unused specs**: If a `storage_alias_spec` has no referencing allocations,
+  the compiler emits a warning.
 
----
+______________________________________________________________________
 
 ## User Fallback Mechanisms
 
-To ensure users always have an escape hatch when the higher-level API is insufficient:
+To ensure users always have an escape hatch when the higher-level API is
+insufficient:
 
-1. **Explicit `buffer_size_bytes`**: The user can specify a size larger than what the compiler would compute, allowing for custom padding or more complex sharing schemes beyond what the reuse group tree can express.
-2. **No `set_buffer_overlap`**: If a `storage_alias_spec` is used without calling `set_buffer_overlap`, all allocations start at offset 0 with no inter-allocation padding. The user can then use buffer count manipulation for manual layout control.
+1. **Explicit `buffer_size_bytes`**: The user can specify a size larger than
+   what the compiler would compute, allowing for custom padding or more complex
+   sharing schemes beyond what the reuse group tree can express.
+1. **No `set_buffer_overlap`**: If a `storage_alias_spec` is used without
+   calling `set_buffer_overlap`, all allocations start at offset 0 with no
+   inter-allocation padding. The user can then use buffer count manipulation for
+   manual layout control.
 
----
+______________________________________________________________________
 
 ## File Summary
 
-| File | Role |
-|------|------|
-| `language/tlx/mem_ops.py` | `storage_alias_spec()` builtin function and updated `local_alloc()` |
-| `language/tlx/types.py` | `storage_alias_spec` class, `storage_alias_spec_type`, `reuse_group` class, `reuse_group_type` enum, `reuse_group_ir_type` |
-| `language/tlx/__init__.py` | Public exports for the API |
-| `dialect/include/IR/TLXOps.td` | MLIR op definitions: `StorageAliasSpecOp`, `StorageAliasLocalAllocOp`, `ReuseGroupOp`, `SetBufferOverlapOp`, `LocalAliasOp` |
-| `dialect/include/IR/TLXTypes.td` | MLIR type definitions: `StorageAliasSpecType`, `ReuseGroupType`, `StorageKindAttr`, `ReuseGroupKindAttr` |
-| `dialect/triton_tlx.cc` | Python-to-IR bindings: `create_storage_alias_spec()`, `create_set_buffer_overlap()`, `create_reuse_group()` |
-| `dialect/lib/Transforms/StorageAliasSizeDefinition.cpp` | Pass Step 1: Compute/validate buffer sizes |
-| `dialect/lib/Transforms/BufferOffsetCalculation.cpp` | Pass Step 2: Compute offsets from reuse group tree |
-| `dialect/lib/Transforms/StorageAliasAllocation.cpp` | Pass Step 3: Materialize allocations, replace ops, rewrite indices |
-| `dialect/lib/Transforms/StorageAliasLowering.cpp` | Combined pass orchestration |
-| `test/TLX/buffer-offset-calculation.mlir` | MLIR-level tests for the offset calculation pass |
-| `python/test/unit/language/test_tlx.py` | Python unit tests for the frontend API and end-to-end compilation |
-| `tutorials/blackwell_fa_ws_pipelined_persistent.py` | Real-world usage example in Flash Attention |
+| File | Role | |------|------| | `language/tlx/mem_ops.py` |
+`storage_alias_spec()` builtin function and updated `local_alloc()` | |
+`language/tlx/types.py` | `storage_alias_spec` class, `storage_alias_spec_type`,
+`reuse_group` class, `reuse_group_type` enum, `reuse_group_ir_type` | |
+`language/tlx/__init__.py` | Public exports for the API | |
+`dialect/include/IR/TLXOps.td` | MLIR op definitions: `StorageAliasSpecOp`,
+`StorageAliasLocalAllocOp`, `ReuseGroupOp`, `SetBufferOverlapOp`, `LocalAliasOp`
+| | `dialect/include/IR/TLXTypes.td` | MLIR type definitions:
+`StorageAliasSpecType`, `ReuseGroupType`, `StorageKindAttr`,
+`ReuseGroupKindAttr` | | `dialect/triton_tlx.cc` | Python-to-IR bindings:
+`create_storage_alias_spec()`, `create_set_buffer_overlap()`,
+`create_reuse_group()` | |
+`dialect/lib/Transforms/StorageAliasSizeDefinition.cpp` | Pass Step 1:
+Compute/validate buffer sizes | |
+`dialect/lib/Transforms/BufferOffsetCalculation.cpp` | Pass Step 2: Compute
+offsets from reuse group tree | |
+`dialect/lib/Transforms/StorageAliasAllocation.cpp` | Pass Step 3: Materialize
+allocations, replace ops, rewrite indices | |
+`dialect/lib/Transforms/StorageAliasLowering.cpp` | Combined pass orchestration
+| | `test/TLX/buffer-offset-calculation.mlir` | MLIR-level tests for the offset
+calculation pass | | `python/test/unit/language/test_tlx.py` | Python unit tests
+for the frontend API and end-to-end compilation | |
+`tutorials/blackwell_fa_ws_pipelined_persistent.py` | Real-world usage example
+in Flash Attention |
 
----
+______________________________________________________________________
 
 ## Future Work
 
-While not covered in the original work, there are several additional opportunities for improvement.
+While not covered in the original work, there are several additional
+opportunities for improvement.
 
 ### Eliminating `set_buffer_overlap`
 
-We can modify the code implementation to eliminate the need for applying the method for each spec. Fundamentally
-the presence of a `reuse_group` is enough to enforce a relationship and the compiler could just collect the "largest"
-reuse for enforcement. This will allow us to eliminate compiler changes and simplify user code.
+We can modify the code implementation to eliminate the need for applying the
+method for each spec. Fundamentally the presence of a `reuse_group` is enough to
+enforce a relationship and the compiler could just collect the "largest" reuse
+for enforcement. This will allow us to eliminate compiler changes and simplify
+user code.
 
 ### Under-Utilization Warning
 
-Currently we don't offer the user insights if they are unnecessarily buffer sharing. For example, with HEAD-DIM=64
-in FA a user might opt not to share all of QK and P, alpha, l, and m since there are 64 columns of leftover TMEM.
-We could write a compiler pass that suggests either removing sharing with P or (alpha/l/m) to maximize available
-TMEM.
+Currently we don't offer the user insights if they are unnecessarily buffer
+sharing. For example, with HEAD-DIM=64 in FA a user might opt not to share all
+of QK and P, alpha, l, and m since there are 64 columns of leftover TMEM. We
+could write a compiler pass that suggests either removing sharing with P or
+(alpha/l/m) to maximize available TMEM.
 
 ### BufferedTensor Reuse Deprecation
 
-We should deprecate the old user of `reuse` in `local_alloc` and require `storage_alias_spec` for clearer ownership
-semantics as sizes change. This will require ensuring the `storage_alias_spec` implementation is well tested across
+We should deprecate the old user of `reuse` in `local_alloc` and require
+`storage_alias_spec` for clearer ownership semantics as sizes change. This will
+require ensuring the `storage_alias_spec` implementation is well tested across
 many kernels.
 
 ### Explicit Buffer Lowering (no reindexing)
 
-Right now we don't lower directly to LLVM with an update base pointer/stride due to potential implications on linear layouts.
-However, this fundamentally makes some reuses impossible to represent and may cause cuda core utilization that can be otherwise
-avoided during the reindexing.
+Right now we don't lower directly to LLVM with an update base pointer/stride due
+to potential implications on linear layouts. However, this fundamentally makes
+some reuses impossible to represent and may cause cuda core utilization that can
+be otherwise avoided during the reindexing.
 
-If we encounter cases where we cannot represent the reuse we should consider the explicit lowering approach and investigate if
-there is actually a real linear layout concern with multi-buffering.
+If we encounter cases where we cannot represent the reuse we should consider the
+explicit lowering approach and investigate if there is actually a real linear
+layout concern with multi-buffering.
 
 #### Moving Layout Alignment
 
-With an explicit buffer offset additional alignment becomes available. For example, its possible that one
-layout which would be optimal for Buffer A is requires 256 byte alignment and its shared with Buffer B that
-desires a 128 byte alignment. Currently the only way this could be achieved is if the single allocation is
-256 byte aligned, which may not always be possible. However, in theory you could just have A start 128 later
-than the original offset. Additionally if there is an external requirement (e.g. TMA requires 128 byte alignment)
-and the buffer size is less than the alignment, explicit padding in the lowering would be needed to maintain the
-128 byte alignment.
+With an explicit buffer offset additional alignment becomes available. For
+example, its possible that one layout which would be optimal for Buffer A is
+requires 256 byte alignment and its shared with Buffer B that desires a 128 byte
+alignment. Currently the only way this could be achieved is if the single
+allocation is 256 byte aligned, which may not always be possible. However, in
+theory you could just have A start 128 later than the original offset.
+Additionally if there is an external requirement (e.g. TMA requires 128 byte
+alignment) and the buffer size is less than the alignment, explicit padding in
+the lowering would be needed to maintain the 128 byte alignment.
 
-It is unclear how critical this is at this time, but this is an avenue of analysis the becomes available once
-we have the lowering capability.
+It is unclear how critical this is at this time, but this is an avenue of
+analysis the becomes available once we have the lowering capability.
 
 ### Reuse groups for kernel for Kernel Fusion
 
-In the abstract Kernel Fusion case its likely that greater buffer reuse will be necessary, potentially in the extreme
-requiring allocating a single buffer and then aliasing it entirely. In that situation its possible a kernel
-will have buffers with differing liveness (e.g. live in for-loop 1 but not for-loop 2).
+In the abstract Kernel Fusion case its likely that greater buffer reuse will be
+necessary, potentially in the extreme requiring allocating a single buffer and
+then aliasing it entirely. In that situation its possible a kernel will have
+buffers with differing liveness (e.g. live in for-loop 1 but not for-loop 2).
 
-While in theory this is may be expressable as a very complicated reuse group, we may want to explore allowing
-`reuse_group` to be applied multiple times and then require that they either have distinct liveness ranges
-or that any buffers used in both have their conditions fixed across both groups (e.g. anchors).
+While in theory this is may be expressable as a very complicated reuse group, we
+may want to explore allowing `reuse_group` to be applied multiple times and then
+require that they either have distinct liveness ranges or that any buffers used
+in both have their conditions fixed across both groups (e.g. anchors).
 
 ### Synchronization Analysis
 
-This is very difficult and most likely not sufficent to capture all bugs, but it may
-be possible to perform static analysis across many more synchronization issues with
-the implicit "metadata" information from reuse groups. Here is the high-level logic
-with a simple example: Imagine we have a reuse group that marks A and B as shared.
-Then based on the compiler guarantees we know that it is never safe to access A[i]
-without a guarantee B[i] is no longer live.
+This is very difficult and most likely not sufficent to capture all bugs, but it
+may be possible to perform static analysis across many more synchronization
+issues with the implicit "metadata" information from reuse groups. Here is the
+high-level logic with a simple example: Imagine we have a reuse group that marks
+A and B as shared. Then based on the compiler guarantees we know that it is
+never safe to access A[i] without a guarantee B[i] is no longer live.
 
-Now this is still very difficult because the code is warp specialized, making it more
-challenging to determine the dependency graph, and the boundaries are barriers, which
-may be possible to fuse together. However, the reuse groups could
-could act as the first of many "metadata infusing operations" which collectively
-may make this possible.
+Now this is still very difficult because the code is warp specialized, making it
+more challenging to determine the dependency graph, and the boundaries are
+barriers, which may be possible to fuse together. However, the reuse groups
+could could act as the first of many "metadata infusing operations" which
+collectively may make this possible.

--- a/extensions/utlx/tlx/doc/tlx_barriers.md
+++ b/extensions/utlx/tlx/doc/tlx_barriers.md
@@ -1,154 +1,145 @@
-#  Barrier Support in TLX
+# Barrier Support in TLX
 
 ## Introduction
 
 ### Barriers
 
-Barriers are primitives that allow synchronization between the warps of
-a kernel. There are full synchronous barriers like \_\_syncthreads(),
-which requires a warp to wait at the barrier until all other warps have
-also reached the barrier. This blocking behavior makes them less
-efficient for implementing patterns like Warp Specialized Producer
-Consumer, where *Producer* warps can fill *buffer0*, notify *Consumers*
-waiting for *buffer0*, then go on to fill *buffer1* without waiting for
-Consumers to finish consuming buffer0.
+Barriers are primitives that allow synchronization between the warps of a
+kernel. There are full synchronous barriers like \_\_syncthreads(), which
+requires a warp to wait at the barrier until all other warps have also reached
+the barrier. This blocking behavior makes them less efficient for implementing
+patterns like Warp Specialized Producer Consumer, where *Producer* warps can
+fill *buffer0*, notify *Consumers* waiting for *buffer0*, then go on to fill
+*buffer1* without waiting for Consumers to finish consuming buffer0.
 
 ### Asynchronous Barriers
 
 Asynchronous Barriers allow semaphore-like *Arrive()* and *Wait()* based
-coordination between warps. Asynchronous Barriers also provide the
-ability to perform synchronization only between a subset of the warps
-(*participating warps*). A warp that does an Arrive() on a barrier does
-not have to wait for other participating warps. The non-participating
-warps can execute independent of the participating warps. The
-participating warps use hardware barrier instructions, over unique
-pre-allocated hardware barrier objects or shared-memory(*shmem*)
-allocated barrier objects, to achieve fine-grained synchronization. On
-certain NVIDIA platforms, asynchronous barriers can also be used to
-track the completion of asynchronous transactions, like TMA loads.
+coordination between warps. Asynchronous Barriers also provide the ability to
+perform synchronization only between a subset of the warps (*participating
+warps*). A warp that does an Arrive() on a barrier does not have to wait for
+other participating warps. The non-participating warps can execute independent
+of the participating warps. The participating warps use hardware barrier
+instructions, over unique pre-allocated hardware barrier objects or
+shared-memory(*shmem*) allocated barrier objects, to achieve fine-grained
+synchronization. On certain NVIDIA platforms, asynchronous barriers can also be
+used to track the completion of asynchronous transactions, like TMA loads.
 
-**Note:** In the remainder of this doc we will refer to Asynchronous
-Barriers as just Barriers.
+**Note:** In the remainder of this doc we will refer to Asynchronous Barriers as
+just Barriers.
 
-**Note:** AMD h/w does not support Asynchronous Barriers but most of the
-TLX barrier operations are implemented in s/w using shared-memory
-variables
+**Note:** AMD h/w does not support Asynchronous Barriers but most of the TLX
+barrier operations are implemented in s/w using shared-memory variables
 
 <p align="center">
   <img src="/third_party/tlx/media/image2.PNG"
   style="width:6.5in;height:4.45833in" />
 
-  Figure 1. Producer Consumer example with Synchronous vs Asynchronous
-  barriers. Producer wave0/wave1 load the first/second half of bufferA and
-  bufferB. Consumer waves use the full buffers. For each wave, the first
-  instruction is assumed to start at the same time, across both scenarios.
-</p>
+Figure 1. Producer Consumer example with Synchronous vs Asynchronous barriers.
+Producer wave0/wave1 load the first/second half of bufferA and bufferB. Consumer
+waves use the full buffers. For each wave, the first instruction is assumed to
+start at the same time, across both scenarios.
 
-#####
+</p>
 
 ### Barrier Operations
 
-Barrier operations can be classified into three categories a)
-*Alloc/Init* b) *Arrive* c) *Wait*
+Barrier operations can be classified into three categories a) *Alloc/Init* b)
+*Arrive* c) *Wait*
 
-*Alloc/Init*
+#### Alloc/Init
 
 - Allocate barrier objects in shmem.
 
-- Initialize barriers with the count of threads that are expected to
-  perform an Arrive operation on the barrier.
+- Initialize barriers with the count of threads that are expected to perform an
+  Arrive operation on the barrier.
 
-- **Note:** This allocation and initialization steps are not required
-  for hardware pre-allocated barriers.
+- **Note:** This allocation and initialization steps are not required for
+  hardware pre-allocated barriers.
 
 - Barriers can also be used to track completion of asynchronous memory
-  transactions (like TMA) and can be initialized with an *expected
-  transaction count*, like bytes transferred in a TMA.
+  transactions (like TMA) and can be initialized with an *expected transaction
+  count*, like bytes transferred in a TMA.
 
-*Arrive*
+#### Arrive
 
-- A warp performs an Arrive on a barrier to indicate completion of some
-  work.
+- A warp performs an Arrive on a barrier to indicate completion of some work.
 
-- Arrive is non-blocking and the warp can proceed as soon as it performs
-  an Arrive.
+- Arrive is non-blocking and the warp can proceed as soon as it performs an
+  Arrive.
 
-- Once the expected number of threads perform an Arrive on the barrier,
-  warps waiting on the barrier become unblocked.
+- Once the expected number of threads perform an Arrive on the barrier, warps
+  waiting on the barrier become unblocked.
 
-- In cases where a barrier is used to track one or more transactions,
-  the Arrive happens implicitly when the transaction is completed. Some
-  examples include:
+- In cases where a barrier is used to track one or more transactions, the Arrive
+  happens implicitly when the transaction is completed. Some examples include:
 
-  - A TMA op will arrive a barrier when it has transferred an expected
-    amount of bytes
+  - A TMA op will arrive a barrier when it has transferred an expected amount of
+    bytes
 
-  - A Blackwell tcgen05 commit op will have a barrier to track all prior
-    async tcgen05 ops initiated by the calling thread. When those ops
-    are done, the barrier will be arrived.
+  - A Blackwell tcgen05 commit op will have a barrier to track all prior async
+    tcgen05 ops initiated by the calling thread. When those ops are done, the
+    barrier will be arrived.
 
-*Wait*
+#### Wait
 
-- A warp performing a Wait is blocked at a barrier until the specified
-  number of Arrive’ing warps reach the barrier or until the expected
-  transaction count is reached.
+- A warp performing a Wait is blocked at a barrier until the specified number of
+  Arrive’ing warps reach the barrier or until the expected transaction count is
+  reached.
 
-- A warp that performs a Wait on a barrier executes independent of other
-  warps waiting at the barrier and such warps can enter and exit the
-  Wait at different times
+- A warp that performs a Wait on a barrier executes independent of other warps
+  waiting at the barrier and such warps can enter and exit the Wait at different
+  times
 
 ## TLX Barriers
 
-TLX provides two categories of barriers a) Named Barriers and b) Memory
-barriers
+TLX provides two categories of barriers a) Named Barriers and b) Memory barriers
 
 ### Named Barriers
 
 - **Note:** Named barriers are only supported on NVIDIA
 
-- Named barriers are h/w pre-allocated barrier objects that are
-  referenced by a number (name of the barrier). The supported range for
-  this number is 0-15 per CTA.
+- Named barriers are h/w pre-allocated barrier objects that are referenced by a
+  number (name of the barrier). The supported range for this number is 0-15 per
+  CTA.
 
 - Named barriers do not have to be allocated or initialized.
 
-- Wait and Arrive are called with the count of expected threads to
-  arrive at the barrier.
+- Wait and Arrive are called with the count of expected threads to arrive at the
+  barrier.
 
-- All threads in the warp participate in the arrive operation, so the
-  thread count should be *number of warps \* threads per warp*
+- All threads in the warp participate in the arrive operation, so the thread
+  count should be *number of warps * threads per warp*
 
 - Suitable for achieving execution patterns like PingPong where a mutual
   exclusive execution order is desired
 
 #### APIs
 
-- ***tlx.named_barrier_wait(bar_id, num_threads)***
-  Wait until num_threads threads have reached the phase of the *bar_id*
-  named barrier. num_threads has to be a multiple of warp size i.e.
-  multiples of 32.
+- ***tlx.named_barrier_wait(bar_id, num_threads)*** Wait until num_threads
+  threads have reached the phase of the *bar_id* named barrier. num_threads has
+  to be a multiple of warp size i.e. multiples of 32.
 
-- ***tlx.named_barrier_arrive(bar_id, num_threads)***
-  Signal arrival at *bar_id* named barrier with an arrival count of
-  *num_threads*. num_threads has to be a multiple of warp size i.e.
-  multiples of 32.
+- ***tlx.named_barrier_arrive(bar_id, num_threads)*** Signal arrival at *bar_id*
+  named barrier with an arrival count of *num_threads*. num_threads has to be a
+  multiple of warp size i.e. multiples of 32.
 
-
-| TLX | MLIR | PTX |
-|----|----|----|
-| tlx.named_barrier_wait | ttng::wait_barrier_named | [<u>bar.sync</u>](https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-bar) |
-| tlx.named_barrier_arrive | ttng::arrive_barrier_named | [<u>bar.arrive</u>](https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-bar) |
+| TLX | MLIR | PTX | |----|----|----| | tlx.named_barrier_wait |
+ttng::wait_barrier_named |
+[bar.sync](https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-bar)
+| | tlx.named_barrier_arrive | ttng::arrive_barrier_named |
+[bar.arrive](https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-bar)
+|
 
 #### Example (PingPong Schedule)
 
-PingPong scheduling creates mutually exclusive ‘Ping’ and ‘Pong’
-execution patterns between warps in order to reduce contention on shared
-hardware resources. To achieve this pattern, code is clustered into Ping
-and Pong clusters, barriers are placed around these clusters, and then a
-subset of the waves are held back from execution behind a conditional
-barrier. The following code snippet, taken from the
-[<u>ws-pipelined-pingpong-flash-attention-fwd
-kernel</u>](https://www.internalfb.com/code/fbsource/third-party/triton/beta/triton/third_party/tlx/tutorials/test_flash-attention-WS-pipelined-pingpong-hopper.py?lines=38)
+PingPong scheduling creates mutually exclusive ‘Ping’ and ‘Pong’ execution
+patterns between warps in order to reduce contention on shared hardware
+resources. To achieve this pattern, code is clustered into Ping and Pong
+clusters, barriers are placed around these clusters, and then a subset of the
+waves are held back from execution behind a conditional barrier. The following
+code snippet, taken from the
+[ws-pipelined-pingpong-flash-attention-fwd kernel](https://www.internalfb.com/code/fbsource/third-party/triton/beta/triton/third_party/tlx/tutorials/test_flash-attention-WS-pipelined-pingpong-hopper.py?lines=38)
 illustrates this idea.
 
 ```python
@@ -169,39 +160,35 @@ if cid == 0:
   qk = tlx.async_dot_wait(0, qk)
 ```
 
-
 The PingPong schedule is achieved using *named barriers* 9 and 10.
 
-This pattern prevents *cid=0* and *cid=1* from executing the
-*tlx.async_dot* at the same time and contending on the Tensor Core
-units. In this kernel, there are 2 consumer warp-groups, with 4 warps
-each, with 32 threads per warp, so the arrive/wait count is set to
-2\*4\*32 = 256.
+This pattern prevents *cid=0* and *cid=1* from executing the *tlx.async_dot* at
+the same time and contending on the Tensor Core units. In this kernel, there are
+2 consumer warp-groups, with 4 warps each, with 32 threads per warp, so the
+arrive/wait count is set to 2\*4\*32 = 256.
 
 ### Memory Barriers
 
-- The kernel has to allocate the *shmem* barrier object and initialize
-  it with an integer *expected* *count* value.
+- The kernel has to allocate the *shmem* barrier object and initialize it with
+  an integer *expected* *count* value.
 
-- The barrier object implicitly tracks the *phase* of the barrier*.*
-  Phase is a 0-initialized boolean value that is toggled every time the
-  following conditions are met:
+- The barrier object implicitly tracks the *phase* of the barrier\*.\* Phase is
+  a 0-initialized boolean value that is toggled every time the following
+  conditions are met:
 
   - The expected count of threads have arrived at the barrier and
 
   - The expected transaction count is reached
 
-- A phase flip is an indication to the Wait’ing warps that the
-  Arrive’ing warps have completed the work that the Wait’ing warps are
-  blocked on.
+- A phase flip is an indication to the Wait’ing warps that the Arrive’ing warps
+  have completed the work that the Wait’ing warps are blocked on.
 
-- CUDA [<u>documentation on
-  phase</u>](https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-mbarrier-phase-completion)
+- CUDA
+  [documentation on phase](https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-mbarrier-phase-completion)
 
-- Wait’ing warps have to maintain the barrier’s phase in a local
-  variable and pass it to the Wait call. The Wait will block until the
-  passed-in phase is not equal to the barrier’s phase i.e. until a
-  barrier phase flip has occurred.
+- Wait’ing warps have to maintain the barrier’s phase in a local variable and
+  pass it to the Wait call. The Wait will block until the passed-in phase is not
+  equal to the barrier’s phase i.e. until a barrier phase flip has occurred.
 
 - Pseudocode for *arrive*
 
@@ -245,46 +232,48 @@ while !done:
 
 #### Barrier APIs
 
-- ***tlx.alloc_barrier(num_barriers, arrive_count=1)**  *
-  Allocates a buffer in shared memory for *num_barrier* barrier objects
-  and initializes them with *arrive_count*. *arrive_count* should be
-  initialized based on the context in which this barrier’s barrier is
-  executed.
+- \***tlx.alloc_barrier(num_barriers, arrive_count=1)** * Allocates a buffer in
+  shared memory for *num_barrier* barrier objects and initializes them with
+  *arrive_count*. *arrive_count* should be initialized based on the context in
+  which this barrier’s barrier is executed.
 
-| Context of arrive | arrive_count | Notes |
-|:---|:---|:---|
-| Implicit arrive of an *tlx.barrier_expect_bytes* | 1 | Only one thread modifies the barrier arrival count after completion of a transaction |
-| *tlx.barrier_arrive* on NV within a *tlx.async_task* region | Number of warp groups | Only one thread per MMA group modifies the barrier arrival count on arrive |
-| *tlx.barrier_arrive* on NV outside a *tlx.async_task* region | 1 | Only tid == 0 modifies the barrier arrival count on arrive |
-| *tlx.barrier_arrive* on AMD | num_warps that execute *tlx.barrier_arrive* | One thread per wave(warp) increments the barrier count |
+| Context of arrive | arrive_count | Notes | |:---|:---|:---| | Implicit arrive
+of an *tlx.barrier_expect_bytes* | 1 | Only one thread modifies the barrier
+arrival count after completion of a transaction | | *tlx.barrier_arrive* on NV
+within a *tlx.async_task* region | Number of warp groups | Only one thread per
+MMA group modifies the barrier arrival count on arrive | | *tlx.barrier_arrive*
+on NV outside a *tlx.async_task* region | 1 | Only tid == 0 modifies the barrier
+arrival count on arrive | | *tlx.barrier_arrive* on AMD | num_warps that execute
+*tlx.barrier_arrive* | One thread per wave(warp) increments the barrier count |
 
-- ***tlx.barrier_expect_bytes(bar, bytes)***
-  Specifies that *bytes* amount of data is expected to be copied before
-  a barrier\_*wait* on *bar* can be unblocked. An implicit arrive will
-  happen on *bar* when the corresponding transaction completes reading
-  *bytes* amount of data.
+- ***tlx.barrier_expect_bytes(bar, bytes)*** Specifies that *bytes* amount of
+  data is expected to be copied before a barrier\_*wait* on *bar* can be
+  unblocked. An implicit arrive will happen on *bar* when the corresponding
+  transaction completes reading *bytes* amount of data.
 
-- ***tlx.barrier_wait(bar, phase)***
-  Wait until the *bar*’s phase has moved ahead of the *phase* argument .
+- ***tlx.barrier_wait(bar, phase)*** Wait until the *bar*’s phase has moved
+  ahead of the *phase* argument .
 
-- ***tlx.barrier_arrive(bar, arrive_count=1)***
-  Performs an arrive operation on *bar*, by decrementing *arrive_count*
-  from the *bar*’s arrival count*.* The phase of *bar* is flipped if
-  bar’s arrival count becomes 0. **Note:** It is recommended to use the
-  barrier_arrive() with arrive_count=1. The *arrive_count* of
-  *tlx.alloc_barrier* can be set to achieve the desired phase change
-  behavior.
+- ***tlx.barrier_arrive(bar, arrive_count=1)*** Performs an arrive operation on
+  *bar*, by decrementing *arrive_count* from the *bar*’s arrival count\*.\* The
+  phase of *bar* is flipped if bar’s arrival count becomes 0. **Note:** It is
+  recommended to use the barrier_arrive() with arrive_count=1. The
+  *arrive_count* of *tlx.alloc_barrier* can be set to achieve the desired phase
+  change behavior.
 
-  | TLX [<u>barriers</u>](https://github.com/facebookexperimental/triton/blob/tlx/third_party/tlx/language/tlx/barrier.py) | MLIR | PTX |
-  |----|----|----|
-  | tlx.alloc_barriers | ttng::InitBarrierOp | [<u>mbarrier.init</u>](https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-mbarrier-init) |
-  | tlx.barrier_expect_bytes | ttng::BarrierExpectOp | [<u>mbarrier.expect_tx</u>](http://mbarrier.expect_tx) |
-  | tlx.barrier_wait | ttng::WaitBarrierOp | [<u>mbarrier.try_wait</u>](http://mbarrier.try_wait) |
-  | tlx.barrier_arrive | ttng::ArriveBarrierOp | [<u>mbarrier.arrive</u>](http://mbarrier.arrive) |
+  | TLX
+  [barriers](https://github.com/facebookexperimental/triton/blob/tlx/third_party/tlx/language/tlx/barrier.py)
+  | MLIR | PTX | |----|----|----| | tlx.alloc_barriers | ttng::InitBarrierOp |
+  [mbarrier.init](https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-mbarrier-init)
+  | | tlx.barrier_expect_bytes | ttng::BarrierExpectOp |
+  [mbarrier.expect_tx](http://mbarrier.expect_tx) | | tlx.barrier_wait |
+  ttng::WaitBarrierOp | [mbarrier.try_wait](http://mbarrier.try_wait) | |
+  tlx.barrier_arrive | ttng::ArriveBarrierOp |
+  [mbarrier.arrive](http://mbarrier.arrive) |
 
 ### Examples
 
-#### WS-GEMM [<u>https://github.com/facebookexperimental/triton/blob/tlx/third_party/tlx/tutorials/gemm-WS-hopper.py</u>](https://github.com/facebookexperimental/triton/blob/tlx/third_party/tlx/tutorials/gemm-WS-hopper.py)
+#### WS-GEMM [https://github.com/facebookexperimental/triton/blob/tlx/third_party/tlx/tutorials/gemm-WS-hopper.py](https://github.com/facebookexperimental/triton/blob/tlx/third_party/tlx/tutorials/gemm-WS-hopper.py)
 
 <p align="center">
   <img src="/third_party/tlx/media/image3.PNG"
@@ -292,28 +281,25 @@ while !done:
   style="width:3.20541in;height:2.44647in" />
 </p>
 
-In the above diagram of GEMM, we have warp specialization with 1
-producer warp group (aka async task in TLX) for TMA load and 2 consumer
-warp groups for MMA. The target tile BMxBN (in green) is computed by
-BMxK (in blue) and KxBN (in yellow) and requires 8 MMA of smaller tiles
-with sizes of (BM/2) x BK and BK x BN. (Dividing BM by 2 because we have
-2 consumer groups)
+In the above diagram of GEMM, we have warp specialization with 1 producer warp
+group (aka async task in TLX) for TMA load and 2 consumer warp groups for MMA.
+The target tile BMxBN (in green) is computed by BMxK (in blue) and KxBN (in
+yellow) and requires 8 MMA of smaller tiles with sizes of (BM/2) x BK and BK x
+BN. (Dividing BM by 2 because we have 2 consumer groups)
 
-TLX mbarriers are used by WS-GEMM for asynchronized communication
-between warp groups. In the simplest case, when TMA WG issues a TMA load
-bonding barFull, the MMA WG waits for barFull before doing MMA. Once the
-TMA load finishes, barFull will arrive and MMA op begins. Once MMA is
-completed, a barEmpty will be marked 'arrived' so that the other waiting
-WG can proceed.
+TLX mbarriers are used by WS-GEMM for asynchronized communication between warp
+groups. In the simplest case, when TMA WG issues a TMA load bonding barFull, the
+MMA WG waits for barFull before doing MMA. Once the TMA load finishes, barFull
+will arrive and MMA op begins. Once MMA is completed, a barEmpty will be marked
+'arrived' so that the other waiting WG can proceed.
 
-Mbarrier contains 'phase' in its opaque object. We flip phase values
-between 0 and 1 each time the current phase completes. In our GEMM
-example, the current phase completes when either TMA load finishes or
-tlx.barrier_arrive is called. To overlap the TMA and MMA operations of
-multiple iterations for latency hiding, we flip phase every 2 (number of
-consumers) iterations as below. TMA load in iter 0 (barFull\[0\]) blocks
-the MMA in iter 0. MMA in iter 0 blocks the TMA load in iter 2 but
-doesn't block the TMA load in iter 1.
+Mbarrier contains 'phase' in its opaque object. We flip phase values between 0
+and 1 each time the current phase completes. In our GEMM example, the current
+phase completes when either TMA load finishes or tlx.barrier_arrive is called.
+To overlap the TMA and MMA operations of multiple iterations for latency hiding,
+we flip phase every 2 (number of consumers) iterations as below. TMA load in
+iter 0 (barFull[0]) blocks the MMA in iter 0. MMA in iter 0 blocks the TMA load
+in iter 2 but doesn't block the TMA load in iter 1.
 
 <p align="center">
   <img src="/third_party/tlx/media/image5.PNG"
@@ -321,12 +307,12 @@ doesn't block the TMA load in iter 1.
 </p>
 
 Now assemble everything together to
-[<u>illustrate</u>](https://www.internalfb.com/excalidraw/EX486624) how
-a BMxBN target tile is calculated. Recall we have (1) 8 (BM/2)xBK
-sub-tiles from A and 4 BKxBN sub-tiles from B (2) 1 TMA WG (producer)
-and 2 MMA WGs (consumer) (3) 4 EmptyA bars, 4 FullA bars, 2 EmptyB bars
-and 2 FullB bars because each WGMMA operation needs two 'full' bars for
-both operands and each TMA load need one 'empty' bar to proceed.
+[illustrate](https://www.internalfb.com/excalidraw/EX486624) how a BMxBN target
+tile is calculated. Recall we have (1) 8 (BM/2)xBK sub-tiles from A and 4 BKxBN
+sub-tiles from B (2) 1 TMA WG (producer) and 2 MMA WGs (consumer) (3) 4 EmptyA
+bars, 4 FullA bars, 2 EmptyB bars and 2 FullB bars because each WGMMA operation
+needs two 'full' bars for both operands and each TMA load need one 'empty' bar
+to proceed.
 
 <p align="center">
 <img src="/third_party/tlx/media/image1.PNG" style="width:6.5in;height:2.5in" />

--- a/extensions/utlx/tlx/doc/tlx_barriers.md
+++ b/extensions/utlx/tlx/doc/tlx_barriers.md
@@ -44,8 +44,8 @@ start at the same time, across both scenarios.
 
 ### Barrier Operations
 
-Barrier operations can be classified into three categories a) *Alloc/Init* b)
-*Arrive* c) *Wait*
+Barrier operations can be classified into three categories: (a) *Alloc/Init*,
+(b) *Arrive*, (c) *Wait*.
 
 #### Alloc/Init
 
@@ -124,12 +124,10 @@ TLX provides two categories of barriers a) Named Barriers and b) Memory barriers
   named barrier with an arrival count of *num_threads*. num_threads has to be a
   multiple of warp size i.e. multiples of 32.
 
-| TLX | MLIR | PTX | |----|----|----| | tlx.named_barrier_wait |
-ttng::wait_barrier_named |
-[bar.sync](https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-bar)
-| | tlx.named_barrier_arrive | ttng::arrive_barrier_named |
-[bar.arrive](https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-bar)
-|
+| TLX                      | MLIR                       | PTX               |
+| ------------------------ | -------------------------- | ----------------- |
+| tlx.named_barrier_wait   | ttng::wait_barrier_named   | [bar.sync][bar]   |
+| tlx.named_barrier_arrive | ttng::arrive_barrier_named | [bar.arrive][bar] |
 
 #### Example (PingPong Schedule)
 
@@ -232,19 +230,17 @@ while !done:
 
 #### Barrier APIs
 
-- \***tlx.alloc_barrier(num_barriers, arrive_count=1)** * Allocates a buffer in
+- ***tlx.alloc_barrier(num_barriers, arrive_count=1)*** Allocates a buffer in
   shared memory for *num_barrier* barrier objects and initializes them with
   *arrive_count*. *arrive_count* should be initialized based on the context in
   which this barrier’s barrier is executed.
 
-| Context of arrive | arrive_count | Notes | |:---|:---|:---| | Implicit arrive
-of an *tlx.barrier_expect_bytes* | 1 | Only one thread modifies the barrier
-arrival count after completion of a transaction | | *tlx.barrier_arrive* on NV
-within a *tlx.async_task* region | Number of warp groups | Only one thread per
-MMA group modifies the barrier arrival count on arrive | | *tlx.barrier_arrive*
-on NV outside a *tlx.async_task* region | 1 | Only tid == 0 modifies the barrier
-arrival count on arrive | | *tlx.barrier_arrive* on AMD | num_warps that execute
-*tlx.barrier_arrive* | One thread per wave(warp) increments the barrier count |
+| Context of arrive                                            | arrive_count                                | Notes                                                                                |
+| :----------------------------------------------------------- | :------------------------------------------ | :----------------------------------------------------------------------------------- |
+| Implicit arrive of an *tlx.barrier_expect_bytes*             | 1                                           | Only one thread modifies the barrier arrival count after completion of a transaction |
+| *tlx.barrier_arrive* on NV within a *tlx.async_task* region  | Number of warp groups                       | Only one thread per MMA group modifies the barrier arrival count on arrive           |
+| *tlx.barrier_arrive* on NV outside a *tlx.async_task* region | 1                                           | Only tid == 0 modifies the barrier arrival count on arrive                           |
+| *tlx.barrier_arrive* on AMD                                  | num_warps that execute *tlx.barrier_arrive* | One thread per wave(warp) increments the barrier count                               |
 
 - ***tlx.barrier_expect_bytes(bar, bytes)*** Specifies that *bytes* amount of
   data is expected to be copied before a barrier\_*wait* on *bar* can be
@@ -261,19 +257,16 @@ arrival count on arrive | | *tlx.barrier_arrive* on AMD | num_warps that execute
   *arrive_count* of *tlx.alloc_barrier* can be set to achieve the desired phase
   change behavior.
 
-  | TLX
-  [barriers](https://github.com/facebookexperimental/triton/blob/tlx/third_party/tlx/language/tlx/barrier.py)
-  | MLIR | PTX | |----|----|----| | tlx.alloc_barriers | ttng::InitBarrierOp |
-  [mbarrier.init](https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-mbarrier-init)
-  | | tlx.barrier_expect_bytes | ttng::BarrierExpectOp |
-  [mbarrier.expect_tx](http://mbarrier.expect_tx) | | tlx.barrier_wait |
-  ttng::WaitBarrierOp | [mbarrier.try_wait](http://mbarrier.try_wait) | |
-  tlx.barrier_arrive | ttng::ArriveBarrierOp |
-  [mbarrier.arrive](http://mbarrier.arrive) |
+  | TLX [barriers]           | MLIR                  | PTX                  |
+  | ------------------------ | --------------------- | -------------------- |
+  | tlx.alloc_barriers       | ttng::InitBarrierOp   | [mbarrier.init]      |
+  | tlx.barrier_expect_bytes | ttng::BarrierExpectOp | [mbarrier.expect_tx] |
+  | tlx.barrier_wait         | ttng::WaitBarrierOp   | [mbarrier.try_wait]  |
+  | tlx.barrier_arrive       | ttng::ArriveBarrierOp | [mbarrier.arrive]    |
 
 ### Examples
 
-#### WS-GEMM [https://github.com/facebookexperimental/triton/blob/tlx/third_party/tlx/tutorials/gemm-WS-hopper.py](https://github.com/facebookexperimental/triton/blob/tlx/third_party/tlx/tutorials/gemm-WS-hopper.py)
+#### WS-GEMM [gemm-WS-hopper.py]
 
 <p align="center">
   <img src="/third_party/tlx/media/image3.PNG"
@@ -317,3 +310,11 @@ to proceed.
 <p align="center">
 <img src="/third_party/tlx/media/image1.PNG" style="width:6.5in;height:2.5in" />
 </p>
+
+[bar]: https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-bar
+[barriers]: https://github.com/facebookexperimental/triton/blob/tlx/third_party/tlx/language/tlx/barrier.py
+[gemm-ws-hopper.py]: https://github.com/facebookexperimental/triton/blob/tlx/third_party/tlx/tutorials/gemm-WS-hopper.py
+[mbarrier.arrive]: https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-mbarrier-arrive
+[mbarrier.expect_tx]: https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-mbarrier-expect-tx
+[mbarrier.init]: https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-mbarrier-init
+[mbarrier.try_wait]: https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-mbarrier-test-wait-try-wait

--- a/pass/README.md
+++ b/pass/README.md
@@ -1,36 +1,47 @@
 # Pass Extension Development
 
-Pass extensions allow you to create custom MLIR passes that can be dynamically loaded into the Triton compiler at
-runtime. These extensions are built as shared libraries and can extend Triton's compilation pipeline without modifying
-the core Triton codebase.
+Pass extensions allow you to create custom MLIR passes that can be dynamically
+loaded into the Triton compiler at runtime. These extensions are built as shared
+libraries and can extend Triton's compilation pipeline without modifying the
+core Triton codebase.
 
 ## Dependencies
 
-All pass extensions depend on the `TritonExtensionSupport` shared library located in [`support`](../support/). See
-it's [documentation](./support/README.md) for more details. Pass extension libraries may also depend on LLVM/MLIR and
-Triton shared libraries; see the top-level [README](../README.md) for more details on setting up these dependencies.
+All pass extensions depend on the `TritonExtensionSupport` shared library
+located in [`support`](../support/). See it's
+[documentation](./support/README.md) for more details. Pass extension libraries
+may also depend on LLVM/MLIR and Triton shared libraries; see the top-level
+[README](../README.md) for more details on setting up these dependencies.
 
 ## Example
 
-The `LoopSplit` extension in `pass/LoopSplit/` demonstrates how to create a pass extension:
+The `LoopSplit` extension in `pass/LoopSplit/` demonstrates how to create a pass
+extension:
 
-1. **Pass Definition**: Use MLIR TableGen to define the pass metadata (see [`Passes.td`](./LoopSplit/Passes.td)).
+1. **Pass Definition**: Use MLIR TableGen to define the pass metadata (see
+   [`Passes.td`](./LoopSplit/Passes.td)).
 
-2. **Pass Implementation**: Implement the pass logic (see [`LoopSplit.cpp`](./LoopSplit/LoopSplit.cpp)). At the end of
-   the file, include the extension registration from the infrastructure library:
+1. **Pass Implementation**: Implement the pass logic (see
+   [`LoopSplit.cpp`](./LoopSplit/LoopSplit.cpp)). At the end of the file,
+   include the extension registration from the infrastructure library:
+
    ```cpp
    // Include the MLIR pass extension registry implementation
    #include "ExportPass.cpp"
    ```
 
-3. **Extension Configuration**: Specify the extension name and status in a `triton-ext.conf` file
-   (see [`triton-ext.conf`](./LoopSplit/triton-ext.conf)):
-   ```
+1. **Extension Configuration**: Specify the extension name and status in a
+   `triton-ext.conf` file (see
+   [`triton-ext.conf`](./LoopSplit/triton-ext.conf)):
+
+   ```txt
    loop_split;experimental
    ```
 
-4. **CMake Configuration**: Set up the build as a shared library with proper dependencies (see
-   [`CMakeLists.txt`](./LoopSplit/CMakeLists.txt)). The `CMakeLists.txt` should define:
+1. **CMake Configuration**: Set up the build as a shared library with proper
+   dependencies (see [`CMakeLists.txt`](./LoopSplit/CMakeLists.txt)). The
+   `CMakeLists.txt` should define:
+
    - `TRITON_EXT_CLASS`: The pass class name (e.g., `LoopBisectPass`)
-   - `TRITON_EXT_NAME`: The extension name (e.g., `loop_bisect`); this is automatically set via
-     the `triton_ext_pass_setup` CMake function
+   - `TRITON_EXT_NAME`: The extension name (e.g., `loop_bisect`); this is
+     automatically set via the `triton_ext_pass_setup` CMake function

--- a/support/README.md
+++ b/support/README.md
@@ -1,21 +1,29 @@
 # Pass Extension Infrastructure
 
-All pass extensions depend on this shared infrastructure library. This library provides:
-- **`Export.{h,cpp}`**: an implementation for Triton's extension API (`tritonAddPluginPass()`,
-  `tritonRegisterPluginPass()`, `tritonEnumeratePluginPasses()`, etc.)
-- **`Export{Pass,Dialect}.cpp`**: automatic registration code that extensions include at the end of their implementation
-  files to enable automatic discovery and registration.
+All pass extensions depend on this shared infrastructure library. This library
+provides:
+
+- **`Export.{h,cpp}`**: an implementation for Triton's extension API
+  (`tritonAddPluginPass()`, `tritonRegisterPluginPass()`,
+  `tritonEnumeratePluginPasses()`, etc.)
+- **`Export{Pass,Dialect}.cpp`**: automatic registration code that extensions
+  include at the end of their implementation files to enable automatic discovery
+  and registration.
 
 ## Build
 
-This library is built as part of the project build; see top-level [README.md](../README.md).
+This library is built as part of the project build; see top-level
+[README.md](../README.md).
 
 ## Use
 
-1. Link against `TritonExtensionSupport` when building your extension (see an [example](../pass/LoopSplit/CMakeLists.txt)).
+1. Link against `TritonExtensionSupport` when building your extension (see an
+   [example](../pass/LoopSplit/CMakeLists.txt)).
 
-2. Include `ExportPass.cpp` at the end of your pass implementation file to enable automatic registration (see an
+1. Include `ExportPass.cpp` at the end of your pass implementation file to
+   enable automatic registration (see an
    [example](../pass/LoopSplit/LoopSplit.cpp)).
 
-3. Inject your extension into Triton at runtime (e.g., `TRITON_PASS_PLUGIN_PATH=/path/to/libmy_pass.so python ...`);
-   this library ensures Triton can discover and load your extension.
+1. Inject your extension into Triton at runtime (e.g.,
+   `TRITON_PASS_PLUGIN_PATH=/path/to/libmy_pass.so python ...`); this library
+   ensures Triton can discover and load your extension.

--- a/testing/README.md
+++ b/testing/README.md
@@ -1,5 +1,6 @@
 # `lit` Testing
 
-This directory contains no `lit` tests itself: it registers the tests available throughout the `triton-ext` project.
-Tests are discovered by the [`lit.cfg.py`](lit.cfg.py) file, with some configuration in
+This directory contains no `lit` tests itself: it registers the tests available
+throughout the `triton-ext` project. Tests are discovered by the
+[`lit.cfg.py`](lit.cfg.py) file, with some configuration in
 [`CMakeLists.txt`](CMakeLists.txt).


### PR DESCRIPTION
These changes apply some formatting to the Markdown files in this repository. Previous commits had introduced different line lengths as files were added; this converges on 80-character line lengths, using `mdformat` to flow the text in a sane way. In doing so, I noticed the table formatting was all over the map; these changes add in `mdformat-gfm` to make tables human-readable in both text and rendered HTML.

The bulk of the changes here to the `*.md` files are automatic: `pre-commit run --all-files`. There were a few cases I manually edited things:
- removed unnecessary `<u>` tags
- extracted some links to Markdown link definitions
- added some code block languages as needed