### PR TITLE
Add development `requirements.txt`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,8 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
-      - name: Upgrade pre-commit package
-        run: python3 -m pip install --upgrade pre-commit
+      - name: Install dependencies
+        run: python3 -m pip install -r requirements.txt
       - name: Check pre-commit
         run: python3 -m pre_commit run --all-files --verbose
       - name: Print diff of changes if pre-commit failed
@@ -73,7 +73,7 @@ jobs:
           echo "PATH=$PATH" >> $GITHUB_ENV
 
           python3 -m pip install --upgrade pip
-          python3 -m pip install lit
+          python3 -m pip install -r requirements.txt
           echo "pip version: $(pip --version)"
           echo "python version: $(python --version)"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-lit==18.1.8
-pre_commit==4.6.0
-requests==2.33.1
+lit~=18.1
+ninja~=1.13
+pre_commit~=4.6
+requests~=2.33

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+lit==18.1.8
+pre_commit==4.6.0
+requests==2.33.1


### PR DESCRIPTION
These seem to be the minimal set of requirements needed to run the `ci` scripts, `lit` tests, etc. Eventually we could add `pytest==9.0.3` once we have Python unit tests running. We could also add `ninja==1.13.0` if users don't have that installed locally (?). In any case, this will be followed up with another PR to document a development setup (after #69).