### PR TITLE
Improve development docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,12 @@ extensions.
 ## Prerequisites
 
 - C++ compiler with C++17 support
-- CMake (3.15 or later)
-- Triton built with TRITON_EXT_ENABLED=ON
+- CMake
+- GitHub CLI ([`gh`]), for downloading pre-built dependencies (optional)
+- Ninja
+- Python 3, for tests and build scripts; install dependencies with
+  `pip install -r requirements.txt`
+- Triton, built with `TRITON_EXT_ENABLED=ON`
 
 Note: Extensions are enabled by default in Triton releases 3.7 and beyond.
 
@@ -81,13 +85,12 @@ To build the extensions:
 
 1. **Build LLVM**: Build LLVM as shared libraries and install it to a known
    location; see the CI [action][build-llvm] for reference. Alternately,
-   download pre-built LLVM binaries from GitHub: install [`gh`] and run
+   download pre-built LLVM binaries from GitHub: run
    `ci/download-artifact.py llvm` [^list-artifacts].
 
 1. **Build Triton**: Build Triton and install it to a known location; see the CI
    [action][build-triton] for reference. Alternately, download pre-built Triton
-   binaries from GitHub: install [`gh`] and run `ci/download-artifact.py triton`
-   [^list-artifacts].
+   binaries from GitHub: run `ci/download-artifact.py triton` [^list-artifacts].
 
 \[^list-artifacts\]: GitHub artifacts are only available for a limited set of
 commits, OSes, and HW architectures. To list available artifacts, run

--- a/README.md
+++ b/README.md
@@ -109,6 +109,14 @@ commits, OSes, and HW architectures. To list available artifacts, run
    CI [workflow](./.github/workflows/ci.yml) for reference. Extensions are built
    as shared libraries under `build/lib`.
 
+## Test
+
+Run the test suite to verify the extensions are working correctly:
+
+```bash
+make test
+```
+
 ## Use
 
 Extensions are loaded by Triton at runtime using the `TRITON_PLUGIN_PATHS`

--- a/README.md
+++ b/README.md
@@ -93,18 +93,18 @@ To build the extensions:
 commits, OSes, and HW architectures. To list available artifacts, run
 `ci/fetch-artifacts.py`.
 
-1. **Configure and build extensions**:
+1. **Build extensions**:
 
    ```bash
-   mkdir build
    export LLVM_INSTALL_DIR=/path/to/llvm/install
    export TRITON_INSTALL_DIR=/path/to/triton/install
-   cmake -S . -B build -G Ninja
-   cmake --build build
+   make build
    ```
 
-   See the CI [workflow](./.github/workflows/ci.yml) for reference. Extensions
-   are built as shared libraries under `build/lib`.
+   Note that if `LLVM_INSTALL_DIR` and `TRITON_INSTALL_DIR` are not set, the
+   `Makefile` will helpfully [search] for them in the project directory. See the
+   CI [workflow](./.github/workflows/ci.yml) for reference. Extensions are built
+   as shared libraries under `build/lib`.
 
 ## Use
 
@@ -133,5 +133,6 @@ export TRITON_PLUGIN_PATHS=build/lib/libutlx.so:build/lib/libother_plugin.so
 
 [build-llvm]: ./.github/actions/build-llvm/action.yml
 [build-triton]: ./.github/actions/build-triton/action.yml
+[search]: ./ci/pick-local-artifact.py
 [triton-plugins]: https://github.com/triton-lang/triton/tree/main/examples/plugins
 [`gh`]: https://cli.github.com/

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ codebase. Extensions are built as shared libraries that can be dynamically
 loaded by Triton at runtime.
 
 Extensions are built on top of the Triton plugin infrastructure documented
-[upstream](https://github.com/triton-lang/triton/tree/main/examples/plugins).
+[upstream][triton-plugins].
 
 Slides from the January 2026 Triton Community Meetup:
 [Triton Community Meetup: Triton Extensions Jan 2026](https://docs.google.com/presentation/d/1dnm8uhvabdwqsQAsaPM7IRpEh2tktQ91E1d40r91n1M/edit?usp=sharing)
@@ -86,12 +86,12 @@ To build the extensions:
 
 1. **Build Triton**: Build Triton and install it to a known location; see the CI
    [action][build-triton] for reference. Alternately, download pre-built Triton
-   binaries from GitHub: install [`gh`] and run `ci/download-artifact.py
-   triton` [^list-artifacts].
+   binaries from GitHub: install [`gh`] and run `ci/download-artifact.py triton`
+   [^list-artifacts].
 
-[^list-artifacts]: GitHub artifacts are only available for a limited set of
-    commits, OSes, and HW architectures. To list available artifacts, run
-    `ci/fetch-artifacts.py`.
+\[^list-artifacts\]: GitHub artifacts are only available for a limited set of
+commits, OSes, and HW architectures. To list available artifacts, run
+`ci/fetch-artifacts.py`.
 
 1. **Configure and build extensions**:
 
@@ -108,20 +108,17 @@ To build the extensions:
 
 ## Use
 
-Pass extensions can be loaded by Triton at runtime using the
-`TRITON_PASS_PLUGIN_PATH` environment variable (see
-[Triton plugins](https://github.com/triton-lang/triton/tree/main/examples/plugins)):
+Extensions are loaded by Triton at runtime using the `TRITON_PLUGIN_PATHS`
+environment variable (see [Triton plugins][triton-plugins]):
 
 ```bash
-export TRITON_PASS_PLUGIN_PATH=/path/to/libmy_pass.so
+export TRITON_PLUGIN_PATHS=/path/to/libmy_pass.so
 python your_script.py
 ```
 
-### Extension Plugins (µTLX)
-
-Extension plugins are loaded via `TRITON_PLUGIN_PATHS`. The µTLX plugin
-automatically registers itself as `triton.language.extra.tlx` when imported, so
-no filesystem symlinks are needed:
+Some extensions are accessible from Python: e.g., the µTLX plugin automatically
+registers itself as `triton.language.extra.tlx` when imported, so no filesystem
+symlinks are needed:
 
 ```bash
 export TRITON_PLUGIN_PATHS=/path/to/triton-ext/build/lib/libutlx.so
@@ -134,7 +131,7 @@ To load multiple plugins, separate paths with `:`:
 export TRITON_PLUGIN_PATHS=build/lib/libutlx.so:build/lib/libother_plugin.so
 ```
 
-
 [build-llvm]: ./.github/actions/build-llvm/action.yml
 [build-triton]: ./.github/actions/build-triton/action.yml
+[triton-plugins]: https://github.com/triton-lang/triton/tree/main/examples/plugins
 [`gh`]: https://cli.github.com/

--- a/README.md
+++ b/README.md
@@ -80,11 +80,18 @@ packaged with `make install`.
 To build the extensions:
 
 1. **Build LLVM**: Build LLVM as shared libraries and install it to a known
-   location; see the CI [action](./.github/actions/build-llvm/action.yml) for
-   reference.
+   location; see the CI [action][build-llvm] for reference. Alternately,
+   download pre-built LLVM binaries from GitHub: install [`gh`] and run
+   `ci/download-artifact.py llvm` [^list-artifacts].
 
 1. **Build Triton**: Build Triton and install it to a known location; see the CI
-   [action](./.github/actions/build-triton/action.yml) for reference.
+   [action][build-triton] for reference. Alternately, download pre-built Triton
+   binaries from GitHub: install [`gh`] and run `ci/download-artifact.py
+   triton` [^list-artifacts].
+
+[^list-artifacts]: GitHub artifacts are only available for a limited set of
+    commits, OSes, and HW architectures. To list available artifacts, run
+    `ci/fetch-artifacts.py`.
 
 1. **Configure and build extensions**:
 
@@ -126,3 +133,8 @@ To load multiple plugins, separate paths with `:`:
 ```bash
 export TRITON_PLUGIN_PATHS=build/lib/libutlx.so:build/lib/libother_plugin.so
 ```
+
+
+[build-llvm]: ./.github/actions/build-llvm/action.yml
+[build-triton]: ./.github/actions/build-triton/action.yml
+[`gh`]: https://cli.github.com/


### PR DESCRIPTION
Over time the `README.md` documentation has drifted out-of-date. This change updates it with several corrections:
- list all dependencies required
- fix environment variable names
- use `make` targets for building and now testing.