### PR TITLE
Use latest version of `checkout` action

### DIFF
--- a/.github/actions/build-llvm/action.yml
+++ b/.github/actions/build-llvm/action.yml
@@ -54,7 +54,7 @@ runs:
 
     - name: Checkout LLVM
       if: steps.check-artifact.outputs.exists == 'false'
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6.0.2
       with:
         repository: llvm/llvm-project
         path: llvm-project

--- a/.github/actions/build-triton/action.yml
+++ b/.github/actions/build-triton/action.yml
@@ -58,7 +58,7 @@ runs:
 
     - name: Checkout triton
       if: steps.check-artifact.outputs.exists == 'false'
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6.0.2
       with:
         repository: triton-lang/triton
         ref: ${{ inputs.triton_hash }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.2
       - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Checkout triton-ext
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Collect commit hashes
         id: hashes

--- a/.github/workflows/update-triton.yml
+++ b/.github/workflows/update-triton.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout triton-ext
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Collect latest Triton commit
         id: hash


### PR DESCRIPTION
This fixes a warning in CI: "Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026."