### PR TITLE
Populate PluginInfo::tritonVersion (fix only)

### DIFF
--- a/extensions/utlx/uTLXPlugin.cpp
+++ b/extensions/utlx/uTLXPlugin.cpp
@@ -13,6 +13,7 @@
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Tools/PluginUtils.h"
+#include "triton/Version.h"
 
 // TLX dialect headers
 #include "tlx/dialect/include/IR/Dialect.h"
@@ -803,6 +804,7 @@ TRITON_PLUGIN_API plugin::PluginInfo *tritonGetPluginInfo() {
       1, // numDialects
       ops,
       48, // numOps
+      TRITON_VERSION,
   };
   return &info;
 }


### PR DESCRIPTION
CI setup took longer than I expect. Create this PR to land the fix first. CI tests will continue on a PR (#79)

Triton commit 8497c845a (#9937) added isTritonAndPluginsVersionsMatch, which dereferences info->tritonVersion unconditionally at plugin load. uTLXPlugin's PluginInfo initializer omitted the field, leaving it nullptr -- std::string construction throws and libtriton import dies with "basic_string::_M_construct null not valid" before any Python-side workaround can run. Pass TRITON_VERSION, matching support/Export.cpp.


