### PR TITLE
TOML extension manifests with enable lever + version, owners from CODEOWNERS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 build
 llvm-*
 triton-*
-!triton-ext.conf
+!triton-ext.toml
 *.pyc

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ To contribute a new extension, follow these steps:
   [`pass`](./pass), etc. If the addition spans multiple top-level directories
   but should not logically be split up, use [`extensions`](./extensions).
 - create a new directory for the addition
-- add the implementation files, CMakeLists.txt, and `triton-ext.conf`; provide
+- add the implementation files, CMakeLists.txt, and `triton-ext.toml`; provide
   tests and ensure they run in `make test`.
 - check that all pre-commit checks pass: `pre-commit run --all-files`
 - open a PR with a clear description of the extension and its functionality, and

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ extensions.
 
 - **[`pass/`](./pass/)**: Contains MLIR pass extensions. Each pass extension is
   implemented as a shared library that can be loaded dynamically. Pass
-  extensions include a `triton-ext.conf` file that specifies the extension name
-  and status.
+  extensions include a `triton-ext.toml` manifest that specifies the extension
+  name and status.
 
 - **[`extensions/`](./extensions/)**: Contains standalone plugin extensions that
   bundle dialects, passes, and language bindings into self-contained shared

--- a/ci/check_extensions.py
+++ b/ci/check_extensions.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Report every extension's build status and owners.
+
+Reads each `triton-ext.toml` manifest and resolves owners from CODEOWNERS.
+
+Usage:
+    python ci/check_extensions.py            # human-readable table
+    python ci/check_extensions.py --json     # machine-readable
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import extension_config
+import extension_owners
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+# Directories that hold downloaded artifacts / build trees, not extensions.
+_SKIP_TOP = ("build", "ci")
+
+
+def discover() -> list[dict]:
+    extensions: list[dict] = []
+    for manifest in sorted(REPO_ROOT.rglob("triton-ext.toml")):
+        rel = manifest.relative_to(REPO_ROOT)
+        if rel.parts[0].startswith(
+            ("triton-", "llvm-")) or rel.parts[0] in _SKIP_TOP:
+            continue
+        cfg = extension_config.load(manifest)
+        ext_dir = manifest.parent.relative_to(REPO_ROOT).as_posix()
+        extensions.append({
+            "name": cfg.name,
+            "dir": ext_dir,
+            "status": cfg.status,
+            "enabled": cfg.enabled,
+            "owners": extension_owners.owners_for(ext_dir),
+        })
+    return extensions
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    extensions = discover()
+    if args.json:
+        print(json.dumps(extensions, indent=2))
+        return 0
+
+    for ext in extensions:
+        flag = "enabled" if ext["enabled"] else "DISABLED"
+        owners = " ".join(ext["owners"]) or "(no owners)"
+        print(f"{ext['name']:<14} {flag:<9} {ext['dir']:<24} owners: {owners}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/extension_config.py
+++ b/ci/extension_config.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Parse a per-extension `triton-ext.toml` manifest.
+
+The one place that understands the manifest format: CMake reads the `--cmake`
+output (a list of `set(KEY "value")` commands) via `include()`, other code
+imports `load()`. Owners are not in the schema -- CODEOWNERS owns that (see
+ci/extension_owners.py).
+
+Schema (all keys optional except `name`):
+    name     str        extension name (the built lib is lib<name>.so)
+    status   str        "experimental" | "stable" (default "experimental")
+    enabled  0 | 1       whether to build this extension (default 1)
+    version  str         extension version, plumbed to C++ as TRITON_EXT_VERSION
+                         (default "0.0.0")
+
+Usage:
+    python ci/extension_config.py <path-to-triton-ext.toml> [--cmake]
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+_VALID_STATUS = {"experimental", "stable"}
+
+
+@dataclass(frozen=True)
+class ExtensionConfig:
+    name: str
+    status: str = "experimental"
+    enabled: bool = True
+    version: str = "0.0.0"
+
+
+def load(manifest_path: Path) -> ExtensionConfig:
+    """Read and validate a triton-ext.toml manifest."""
+    with open(manifest_path, "rb") as f:
+        data = tomllib.load(f)
+
+    name = data.get("name")
+    if not name or not isinstance(name, str):
+        raise ValueError(
+            f"{manifest_path}: missing required string field 'name'")
+
+    status = data.get("status", "experimental")
+    if status not in _VALID_STATUS:
+        raise ValueError(
+            f"{manifest_path}: status '{status}' must be one of {sorted(_VALID_STATUS)}"
+        )
+
+    enabled = data.get("enabled", 1)
+    if enabled not in (0, 1):
+        raise ValueError(f"{manifest_path}: 'enabled' must be 0 or 1")
+
+    version = data.get("version", "0.0.0")
+    if not isinstance(version, str):
+        raise ValueError(f"{manifest_path}: 'version' must be a string")
+
+    return ExtensionConfig(name=name,
+                           status=status,
+                           enabled=bool(enabled),
+                           version=version)
+
+
+def _as_cmake(cfg: ExtensionConfig) -> str:
+    """Emit `set(KEY "value")` commands for CMake to include()."""
+    lines = [
+        f'set(TRITON_EXT_NAME "{cfg.name}")',
+        f'set(TRITON_EXT_STATUS "{cfg.status}")',
+        f'set(TRITON_EXT_ENABLED "{"ON" if cfg.enabled else "OFF"}")',
+        f'set(TRITON_EXT_VERSION "{cfg.version}")',
+    ]
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("manifest", type=Path, help="path to triton-ext.toml")
+    parser.add_argument("--cmake",
+                        action="store_true",
+                        help="emit set(KEY \"value\") commands for CMake")
+    args = parser.parse_args()
+
+    try:
+        cfg = load(args.manifest)
+    except (OSError, ValueError, tomllib.TOMLDecodeError) as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
+
+    if args.cmake:
+        print(_as_cmake(cfg))
+    else:
+        print(f"name={cfg.name} status={cfg.status} enabled={cfg.enabled} "
+              f"version={cfg.version}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/extension_owners.py
+++ b/ci/extension_owners.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Resolve the owners of a path from `.github/CODEOWNERS`.
+
+Implements the subset of CODEOWNERS matching we rely on (last-matching-pattern
+wins, leading-slash anchoring, trailing-slash directory patterns); not a full
+glob engine.
+
+Usage:
+    python ci/extension_owners.py <path> [--codeowners <file>]
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_CODEOWNERS = REPO_ROOT / ".github" / "CODEOWNERS"
+
+
+def _parse(codeowners_path: Path) -> list[tuple[str, list[str]]]:
+    rules: list[tuple[str, list[str]]] = []
+    for raw in codeowners_path.read_text().splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if not line:
+            continue
+        parts = line.split()
+        pattern, owners = parts[0], parts[1:]
+        rules.append((pattern, owners))
+    return rules
+
+
+def _matches(pattern: str, path: str) -> bool:
+    """Match a CODEOWNERS pattern against a repo-relative POSIX path."""
+    if pattern == "*":
+        return True
+    anchored = pattern.startswith("/")
+    pat = pattern.lstrip("/")
+    # A trailing slash matches a directory and everything beneath it.
+    if pat.endswith("/"):
+        pat = pat.rstrip("/")
+        return path == pat or path.startswith(pat + "/")
+    if anchored:
+        return path == pat or path.startswith(pat + "/")
+    # Unanchored: match the segment anywhere in the path.
+    segments = path.split("/")
+    return pat in segments or path == pat or path.startswith(pat + "/")
+
+
+def owners_for(path: str,
+               codeowners_path: Path = DEFAULT_CODEOWNERS) -> list[str]:
+    """Return the owners for a repo-relative path (last matching rule wins)."""
+    path = path.strip("/")
+    result: list[str] = []
+    for pattern, owners in _parse(codeowners_path):
+        if _matches(pattern, path):
+            result = owners
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("path", help="repo-relative path to resolve")
+    parser.add_argument("--codeowners", type=Path, default=DEFAULT_CODEOWNERS)
+    args = parser.parse_args()
+
+    owners = owners_for(args.path, args.codeowners)
+    if not owners:
+        print(f"no owners found for {args.path}", file=sys.stderr)
+        return 1
+    print(" ".join(owners))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -45,43 +45,59 @@ function(triton_ext_check_triton_hash result_var)
     endif()
 endfunction()
 
+# triton_ext_read_manifest(<triton_ext_dir>)
+# Reads triton-ext.toml via ci/extension_config.py and sets TRITON_EXT_NAME,
+# TRITON_EXT_STATUS, TRITON_EXT_ENABLED, TRITON_EXT_VERSION in the caller's scope.
+function(triton_ext_read_manifest triton_ext_dir)
+    set(manifest "${triton_ext_dir}/triton-ext.toml")
+    if(NOT EXISTS ${manifest})
+        message(FATAL_ERROR "Extension manifest not found: ${manifest}")
+    endif()
+
+    find_package(Python3 COMPONENTS Interpreter REQUIRED)
+    set(generated "${CMAKE_CURRENT_BINARY_DIR}/triton-ext-manifest.cmake")
+    execute_process(
+        COMMAND ${Python3_EXECUTABLE}
+                "${CMAKE_SOURCE_DIR}/ci/extension_config.py" "${manifest}" --cmake
+        OUTPUT_FILE "${generated}"
+        RESULT_VARIABLE _manifest_rc
+    )
+    if(NOT _manifest_rc EQUAL 0)
+        message(FATAL_ERROR "Failed to parse ${manifest}")
+    endif()
+
+    include("${generated}")
+    set(TRITON_EXT_NAME "${TRITON_EXT_NAME}" PARENT_SCOPE)
+    set(TRITON_EXT_STATUS "${TRITON_EXT_STATUS}" PARENT_SCOPE)
+    set(TRITON_EXT_ENABLED "${TRITON_EXT_ENABLED}" PARENT_SCOPE)
+    set(TRITON_EXT_VERSION "${TRITON_EXT_VERSION}" PARENT_SCOPE)
+endfunction()
+
 # Function to check if a Triton extension should be built
 # Usage: triton_ext_should_build_extension(<triton_ext_dir> <result_var>)
 #   triton_ext_dir: Path to the Triton extension directory
 #   result_var: Variable to store the result
 function(triton_ext_should_build_extension triton_ext_dir result_var)
-    set(config_file "${triton_ext_dir}/triton-ext.conf")
-    # Default to FALSE
     set(${result_var} FALSE PARENT_SCOPE)
+    if(NOT EXISTS "${triton_ext_dir}/triton-ext.toml")
+        return()
+    endif()
 
-    # Try to read from config file first
-    if(EXISTS ${config_file})
-        file(READ ${config_file} _config_content)
-        string(STRIP "${_config_content}" _config_content)
-        # Parse the config file (format: name;status or just name)
-        # Config file must be in CMake list format (semicolon-separated)
-        if(_config_content)
-            set(_config_list ${_config_content})
-            list(LENGTH _config_list _num_parts)
-            if(_num_parts GREATER_EQUAL 1)
-                list(GET _config_list 0 _ext_name)
-                string(STRIP "${_ext_name}" _ext_name)
-            else()
-                set(_ext_name ${_config_content})
-                string(STRIP "${_ext_name}" _ext_name)
-            endif()
-            # Check if _ext_name is in TRITON_EXT_NAMES
-            list(LENGTH TRITON_EXT_NAMES _size)
-            if(NOT _size EQUAL 0)
-                list(FIND TRITON_EXT_NAMES "${_ext_name}" _index)
-                if(NOT _index EQUAL -1)
-                    # If _ext_name is in TRITON_EXT_NAMES, set result to TRUE
-                    set(${result_var} TRUE PARENT_SCOPE)
-                endif()
-            else()
-                # If TRITON_EXT_NAMES is empty, default to TRUE
-                set(${result_var} TRUE PARENT_SCOPE)
-            endif()
+    triton_ext_read_manifest("${triton_ext_dir}")
+
+    if(NOT TRITON_EXT_ENABLED)
+        message(STATUS "Skipping disabled extension '${TRITON_EXT_NAME}'")
+        return()
+    endif()
+
+    # When TRITON_EXT_NAMES is set, build only the names it lists.
+    list(LENGTH TRITON_EXT_NAMES _size)
+    if(_size EQUAL 0)
+        set(${result_var} TRUE PARENT_SCOPE)
+    else()
+        list(FIND TRITON_EXT_NAMES "${TRITON_EXT_NAME}" _index)
+        if(NOT _index EQUAL -1)
+            set(${result_var} TRUE PARENT_SCOPE)
         endif()
     endif()
 endfunction()
@@ -94,56 +110,21 @@ endfunction()
 # - ext_class: the extension class name (required)
 #
 # Outputs (set as CMake variables):
-# - TRITON_EXT_CONFIG_FILE: path to the extension's triton-ext.conf file
-# - TRITON_EXT_NAME: extension name (from config file)
+# - TRITON_EXT_NAME: extension name (from manifest)
 # - TRITON_EXT_CLASS: extension class (from argument)
-# - TRITON_EXT_STATUS: extension status (from config file, default "experimental")
-# - TRITON_EXT_HASH: expected Triton git hash (from config file, optional)
+# - TRITON_EXT_STATUS: extension status (from manifest, default "experimental")
+# - TRITON_EXT_VERSION: extension version (from manifest); also a compile def
 # - Adds the extension project name to the global TRITON_EXT_BUILT_TARGETS list
 macro(triton_extension ext_class)
-    # Read extension name, status, and hash from local triton-ext.conf file
-    set(TRITON_EXT_CONFIG_FILE "${CMAKE_CURRENT_SOURCE_DIR}/triton-ext.conf")
-    set(_ext_name "")
-    set(_status "experimental")
-    set(_hash "")
+    triton_ext_read_manifest("${CMAKE_CURRENT_SOURCE_DIR}")
 
-    if(EXISTS ${TRITON_EXT_CONFIG_FILE})
-        file(READ ${TRITON_EXT_CONFIG_FILE} _config_content)
-        string(STRIP "${_config_content}" _config_content)
-
-        if(_config_content)
-            # Config file is in CMake list format (semicolon-separated): name;status;hash
-            set(_config_list ${_config_content})
-            list(LENGTH _config_list _num_parts)
-
-            if(_num_parts GREATER_EQUAL 1)
-                list(GET _config_list 0 _ext_name)
-                string(STRIP "${_ext_name}" _ext_name)
-            endif()
-
-            if(_num_parts GREATER_EQUAL 2)
-                list(GET _config_list 1 _status)
-                string(STRIP "${_status}" _status)
-            endif()
-
-            if(_num_parts GREATER_EQUAL 3)
-                list(GET _config_list 2 _hash)
-                string(STRIP "${_hash}" _hash)
-            endif()
-        endif()
+    if(NOT TRITON_EXT_NAME)
+        message(FATAL_ERROR "triton-ext.toml not found or missing 'name' in ${CMAKE_CURRENT_SOURCE_DIR}")
     endif()
 
-    if(NOT _ext_name)
-        message(FATAL_ERROR "triton_ext.conf file not found or empty in ${CMAKE_CURRENT_SOURCE_DIR}")
-    endif()
-
-    project(${_ext_name})
-    set(TRITON_EXT_NAME ${PROJECT_NAME})
+    project(${TRITON_EXT_NAME})
     set(TRITON_EXT_CLASS ${ext_class})
-    set(TRITON_EXT_STATUS ${_status})
-    if(_hash)
-        set(TRITON_EXT_HASH ${_hash})
-    endif()
+    add_compile_definitions(TRITON_EXT_VERSION="${TRITON_EXT_VERSION}")
 
     set_property(GLOBAL APPEND PROPERTY TRITON_EXT_BUILT_TARGETS ${PROJECT_NAME})
 endmacro()

--- a/dialect/Example/triton-ext.conf
+++ b/dialect/Example/triton-ext.conf
@@ -1,1 +1,0 @@
-example;experimental

--- a/dialect/Example/triton-ext.toml
+++ b/dialect/Example/triton-ext.toml
@@ -1,0 +1,4 @@
+name = "example"
+status = "experimental"
+enabled = 1
+version = "0.1.0"

--- a/extensions/utlx/triton-ext.conf
+++ b/extensions/utlx/triton-ext.conf
@@ -1,1 +1,0 @@
-utlx;experimental

--- a/extensions/utlx/triton-ext.toml
+++ b/extensions/utlx/triton-ext.toml
@@ -1,0 +1,4 @@
+name = "utlx"
+status = "experimental"
+enabled = 1
+version = "0.1.0"

--- a/extensions/utlx/uTLXPlugin.cpp
+++ b/extensions/utlx/uTLXPlugin.cpp
@@ -15,6 +15,10 @@
 #include "triton/Tools/PluginUtils.h"
 #include "triton/Version.h"
 
+#ifndef TRITON_EXT_VERSION
+#define TRITON_EXT_VERSION "0.0.0"
+#endif
+
 // TLX dialect headers
 #include "tlx/dialect/include/IR/Dialect.h"
 #include "tlx/dialect/include/Transforms/Passes.h"
@@ -695,37 +699,37 @@ using namespace mlir::triton;
 
 TRITON_PLUGIN_API plugin::PluginInfo *tritonGetPluginInfo() {
   static plugin::PassInfo passes[] = {
-      {"utlx_convert_triton_to_tritongpu", "0.1.0", addUTLXConversionPass,
-       registerUTLXConversionPass},
-      {"utlx_insert_and_propagate_layout", "0.1.0",
+      {"utlx_convert_triton_to_tritongpu", TRITON_EXT_VERSION,
+       addUTLXConversionPass, registerUTLXConversionPass},
+      {"utlx_insert_and_propagate_layout", TRITON_EXT_VERSION,
        addUTLXInsertAndPropagatePass, registerUTLXInsertAndPropagatePass},
-      {"utlx_fixup", "0.1.0", addTLXFixupPass, registerTLXFixupPass},
-      {"utlx_propagate_layout", "0.1.0", addPropagateLayoutPass,
+      {"utlx_fixup", TRITON_EXT_VERSION, addTLXFixupPass, registerTLXFixupPass},
+      {"utlx_propagate_layout", TRITON_EXT_VERSION, addPropagateLayoutPass,
        registerPropagateLayoutPass},
-      {"utlx_insert_require_layout", "0.1.0", addInsertRequireLayoutPass,
+      {"utlx_insert_require_layout", TRITON_EXT_VERSION,
+       addInsertRequireLayoutPass, noopRegister},
+      {"utlx_rewrite_local_alias", TRITON_EXT_VERSION, addRewriteLocalAliasPass,
        noopRegister},
-      {"utlx_rewrite_local_alias", "0.1.0", addRewriteLocalAliasPass,
-       noopRegister},
-      {"utlx_resolve_placeholder_layouts", "0.1.0",
+      {"utlx_resolve_placeholder_layouts", TRITON_EXT_VERSION,
        addResolvePlaceholderLayoutsPass, noopRegister},
-      {"utlx_print_ttgir_to_tlx", "0.1.0", addPrintTTGIRToTLXPass,
+      {"utlx_print_ttgir_to_tlx", TRITON_EXT_VERSION, addPrintTTGIRToTLXPass,
        noopRegister},
-      {"utlx_storage_alias_lowering", "0.1.0", addStorageAliasLoweringPass,
-       noopRegister},
+      {"utlx_storage_alias_lowering", TRITON_EXT_VERSION,
+       addStorageAliasLoweringPass, noopRegister},
       // Ported NVIDIA passes
-      {"utlx_prune_unused_barriers", "0.1.0", addPruneUnusedBarriersPass,
-       registerPruneUnusedBarriersPassFn},
-      {"utlx_ping_pong_prep", "0.1.0", addPingPongPrepPass,
+      {"utlx_prune_unused_barriers", TRITON_EXT_VERSION,
+       addPruneUnusedBarriersPass, registerPruneUnusedBarriersPassFn},
+      {"utlx_ping_pong_prep", TRITON_EXT_VERSION, addPingPongPrepPass,
        registerPingPongPrepPassFn},
-      {"utlx_ping_pong_sync", "0.1.0", addPingPongSyncPass,
+      {"utlx_ping_pong_sync", TRITON_EXT_VERSION, addPingPongSyncPass,
        registerPingPongSyncPassFn},
       // Ported AMD passes (disabled until patched triton is available)
-      // {"utlx_amd_lower_barrier_ops", "0.1.0",
+      // {"utlx_amd_lower_barrier_ops", TRITON_EXT_VERSION,
       //  addAMDLowerBarrierOpsPass, registerAMDLowerBarrierOpsPassFn},
   };
 
   static plugin::DialectInfo dialects[] = {
-      {"TLXDialect", "0.1.0", registerTLXDialect},
+      {"TLXDialect", TRITON_EXT_VERSION, registerTLXDialect},
   };
 
   static plugin::OpInfo ops[] = {
@@ -797,7 +801,7 @@ TRITON_PLUGIN_API plugin::PluginInfo *tritonGetPluginInfo() {
   static plugin::PluginInfo info = {
       TRITON_PLUGIN_API_VERSION,
       "uTLXPlugin",
-      "0.1.0",
+      TRITON_EXT_VERSION,
       passes,
       12, // numPasses
       dialects,

--- a/pass/LoopSplit/triton-ext.conf
+++ b/pass/LoopSplit/triton-ext.conf
@@ -1,1 +1,0 @@
-loop_split;experimental

--- a/pass/LoopSplit/triton-ext.toml
+++ b/pass/LoopSplit/triton-ext.toml
@@ -1,0 +1,4 @@
+name = "loop_split"
+status = "experimental"
+enabled = 1
+version = "0.1.0"

--- a/pass/README.md
+++ b/pass/README.md
@@ -31,11 +31,13 @@ extension:
    ```
 
 1. **Extension Configuration**: Specify the extension name and status in a
-   `triton-ext.conf` file (see
-   [`triton-ext.conf`](./LoopSplit/triton-ext.conf)):
+   `triton-ext.toml` manifest (see
+   [`triton-ext.toml`](./LoopSplit/triton-ext.toml)):
 
-   ```txt
-   loop_split;experimental
+   ```toml
+   name = "loop_split"
+   status = "experimental"
+   enabled = 1
    ```
 
 1. **CMake Configuration**: Set up the build as a shared library with proper

--- a/testing/test_plugins.py
+++ b/testing/test_plugins.py
@@ -1,8 +1,10 @@
 """Plugin integration tests.
 
-Auto-discovers every plugin declared by a `triton-ext.conf` and exercises
+Auto-discovers every plugin declared by a `triton-ext.toml` and exercises
 its `lib<name>.so` from a fresh Python interpreter with `TRITON_PLUGIN_PATHS`
 set. Each plugin runs in its own subprocess so failures isolate cleanly.
+Extensions with `enabled = 0` in their manifest are not built, so they are
+skipped during discovery.
 
 Tests:
   - test_plugin_loads[<name>]            -- plugin static-init: `import triton`
@@ -14,7 +16,7 @@ Tests:
                                             with `@pytest.mark.skipif` on the
                                             plugin's .so existence.
 
-Adding a new plugin: drop a `triton-ext.conf`; both parametrized tests pick
+Adding a new plugin: drop a `triton-ext.toml`; both parametrized tests pick
 it up. To exempt a plugin from a parametrized test, mark it at parametrize
 time with `pytest.param(..., marks=pytest.mark.skip(...))` -- see
 `_COMPILE_PLUGINS` for an example.
@@ -40,21 +42,21 @@ BUILD_DIR = Path(os.environ.get("TRITON_EXT_BUILD_DIR", REPO_ROOT / "build"))
 PLUGIN_LIB_DIR = BUILD_DIR / "lib"
 SCRIPTS_DIR = Path(__file__).resolve().parent / "scripts"
 
+sys.path.insert(0, str(REPO_ROOT / "ci"))
+import extension_config  # noqa: E402  (ci/ is added to sys.path above)
+
 
 def _discover_plugins() -> list[pytest.ParameterSet]:
     plugins: list[pytest.ParameterSet] = []
-    for conf in REPO_ROOT.rglob("triton-ext.conf"):
-        rel_parts = conf.relative_to(REPO_ROOT).parts
+    for manifest in REPO_ROOT.rglob("triton-ext.toml"):
+        rel_parts = manifest.relative_to(REPO_ROOT).parts
         if rel_parts[0].startswith(("triton-", "llvm-", "build")):
             continue
-        text = conf.read_text().strip()
-        if not text:
+        cfg = extension_config.load(manifest)
+        # Disabled extensions are not built, so do not parametrize them.
+        if not cfg.enabled:
             continue
-        # Format is `name;status[;hash]` (CMake list); we only need the name.
-        name = text.split(";", 1)[0].strip()
-        if not name:
-            continue
-        plugins.append(pytest.param(name, id=name))
+        plugins.append(pytest.param(cfg.name, id=cfg.name))
     plugins.sort(key=lambda p: p.id)
     return plugins
 
@@ -96,7 +98,7 @@ def _run(env_overrides: dict[str, str],
 
 def test_plugins_discovered() -> None:
     """Guard against silently testing nothing if discovery breaks."""
-    assert PLUGINS, f"No triton-ext.conf files found under {REPO_ROOT}"
+    assert PLUGINS, f"No triton-ext.toml files found under {REPO_ROOT}"
 
 
 @pytest.mark.parametrize("name", PLUGINS)


### PR DESCRIPTION
Replaces the semicolon-delimited triton-ext.conf with a triton-ext.toml manifest parsed by Python (ci/extension_config.py), which emits set(KEY "value") commands that CMake include()s -- no manifest parsing in CMake.

Manifest fields:
  - enabled = 0|1 gates the build: a disabled extension is skipped at configure time and dropped from test discovery, so a broken extension can be parked without removing it.
  - version is plumbed to C++ as the TRITON_EXT_VERSION compile definition (replacing the hard-coded "0.1.0" version strings in utlx's PassInfo table).

Owners are resolved from .github/CODEOWNERS (ci/extension_owners.py) rather than duplicated into each manifest. ci/check_extensions.py reports status and owners.