### PR TITLE
Move `discover()` manifests; use in tests

### DIFF
--- a/ci/check-extensions.py
+++ b/ci/check-extensions.py
@@ -16,28 +16,6 @@ from pathlib import Path
 
 import extension
 
-REPO_ROOT = Path(__file__).resolve().parent.parent
-
-
-def out_of_place(path: Path) -> bool:
-    """Return True if the path is not in a valid extension directory."""
-    SEARCH_DIRECTORIES = ("backend", "dialect", "extensions", "language",
-                          "pass")
-    return not any(
-        path.is_relative_to(REPO_ROOT / d) for d in SEARCH_DIRECTORIES)
-
-
-def discover() -> list[extension.Manifest]:
-    """Find all `triton-ext.toml` files and parse them into structured metadata."""
-    extensions = []
-    for manifest in sorted(REPO_ROOT.rglob("triton-ext.toml")):
-        if out_of_place(manifest):
-            raise ValueError(
-                f"extension manifest found in unexpected location: {manifest}")
-        cfg = extension.load(manifest)
-        extensions.append(cfg)
-    return extensions
-
 
 def path_as_str(p):
     """When serializing to JSON, convert Path objects to strings."""
@@ -49,7 +27,7 @@ def main() -> int:
     parser.add_argument("--json", action="store_true")
     args = parser.parse_args()
 
-    extensions = discover()
+    extensions = extension.discover()
     if args.json:
         # Serializing a @dataclass with Path fields requires some special
         # handling.

--- a/ci/extension.py
+++ b/ci/extension.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Parse the `triton-ext.toml` manifest: see :load:.
+Parse the `triton-ext.toml` manifest: see :load: and :discover:.
 
 This also understands parsing a CODEOWNERS file to associate a list of owners
 with an extension: see :parse_codeowners: and :owners_for:.
@@ -129,6 +129,33 @@ def load(manifest_path: Path) -> Manifest:
                     enabled=data.get("enabled", True),
                     version=data.get("version", "0.0.0"),
                     owners=owners)
+
+
+def _out_of_place(path: Path) -> bool:
+    """
+    Return True if the path is not in a valid extension directory.
+
+    >>> _out_of_place(REPO_ROOT / "extensions" / "foo" / "triton-ext.toml")
+    False
+    >>> _out_of_place(REPO_ROOT / "triton-7a5d6a3d-linux-x64" / "triton-ext.toml")
+    True
+    """
+    SEARCH_DIRECTORIES = ("backend", "dialect", "extensions", "language",
+                          "pass")
+    return not any(
+        path.is_relative_to(REPO_ROOT / d) for d in SEARCH_DIRECTORIES)
+
+
+def discover() -> list[Manifest]:
+    """Find all `triton-ext.toml` files and load them into structured metadata."""
+    extensions = []
+    for manifest in sorted(REPO_ROOT.rglob("triton-ext.toml")):
+        if _out_of_place(manifest):
+            raise ValueError(
+                f"extension manifest found in unexpected location: {manifest}")
+        cfg = load(manifest)
+        extensions.append(cfg)
+    return extensions
 
 
 if __name__ == "__main__":

--- a/testing/test_plugins.py
+++ b/testing/test_plugins.py
@@ -49,15 +49,9 @@ import extension  # noqa: E402  (ci/ is added to sys.path above)
 
 def _discover_plugins() -> list[pytest.ParameterSet]:
     plugins: list[pytest.ParameterSet] = []
-    for manifest in REPO_ROOT.rglob("triton-ext.toml"):
-        rel_parts = manifest.relative_to(REPO_ROOT).parts
-        if rel_parts[0].startswith(("triton-", "llvm-", "build")):
-            continue
-        cfg = extension.load(manifest)
-        # Disabled extensions are not built, so do not parametrize them.
-        if not cfg.enabled:
-            continue
-        plugins.append(pytest.param(cfg.name, id=cfg.name))
+    for cfg in extension.discover():
+        if cfg.enabled:
+            plugins.append(pytest.param(cfg.name, id=cfg.name))
     plugins.sort(key=lambda p: p.id)
     return plugins
 


### PR DESCRIPTION
This change moves the extension discovery into the `extension` module so that we can use the same logic in `check-extensions.py` and the `test_plugins.py` test. No logic should change; it just deduplicates the mechanism for discovering extensions.