### PR TITLE
ci: resolve manifest path symlinks in extension loader

### DIFF
--- a/ci/extension.py
+++ b/ci/extension.py
@@ -121,7 +121,9 @@ def load(manifest_path: Path) -> Manifest:
     with open(manifest_path, "rb") as f:
         data = tomllib.load(f)
     rules = parse_codeowners(DEFAULT_CODEOWNERS)
-    path = manifest_path.absolute().relative_to(REPO_ROOT)
+    # Resolve symlinks so the comparison is consistent with REPO_ROOT (which is
+    # also resolved); otherwise a symlinked checkout breaks `relative_to`.
+    path = manifest_path.resolve().relative_to(REPO_ROOT)
     owners = owners_for(path.as_posix(), rules)
     return Manifest(name=data["name"],
                     path=path,


### PR DESCRIPTION
`load()` computed the repo-relative manifest path with `manifest_path.absolute()`, but `REPO_ROOT` is `.resolve()`d. On a checkout reached through a symlink the two disagree, so `relative_to` raises and breaks manifest parsing during CMake configure. Resolve the manifest path as well so both sides are consistent.



Assisted-by: Cursor