### PR TITLE
utlx: prepend `add_` and `create_` to plugin passes/operations

### DIFF
--- a/extensions/utlx/python/utlx_plugin/barrier.py
+++ b/extensions/utlx/python/utlx_plugin/barrier.py
@@ -34,7 +34,7 @@ def alloc_barriers(
     arrive_count_ir = _semantic.builder.get_int32(int(arrive_count_val))
 
     args = [num_barriers_ir, arrive_count_ir]
-    handle = _semantic.builder.utlx_alloc_barriers(args)
+    handle = _semantic.builder.create_utlx_alloc_barriers(args)
 
     layout = tlx.swizzled_shared_layout_encoding.make_default(rank=1)
     return tlx.mbarrier(handle, num_barriers_val, layout)
@@ -57,7 +57,7 @@ def alloc_warp_barrier(
     arrive_count_ir = _semantic.builder.get_int32(int(arrive_count))
 
     args = [num_barriers_ir, arrive_count_ir]
-    handle = _semantic.builder.utlx_alloc_barriers(args)
+    handle = _semantic.builder.create_utlx_alloc_barriers(args)
 
     layout = tlx.swizzled_shared_layout_encoding.make_default(rank=1)
     return tlx.mbarrier(handle, num_barriers_val, layout, is_warp_barrier=True)
@@ -79,7 +79,8 @@ def barrier_expect_bytes(
     size_val = tl._unwrap_if_constexpr(size)
     size_ir = _semantic.builder.get_int32(int(size_val))
 
-    _semantic.builder.utlx_barrier_expect([bar.handle, size_ir, pred_handle])
+    _semantic.builder.create_utlx_barrier_expect(
+        [bar.handle, size_ir, pred_handle])
 
 
 @tl.builtin
@@ -107,7 +108,7 @@ def barrier_wait(
         raise RuntimeError(
             f"`phase` must be tl.tensor or tl.constexpr, got {type(phase)}")
 
-    _semantic.builder.utlx_barrier_wait(
+    _semantic.builder.create_utlx_barrier_wait(
         [bar.handle, phase_handle, pred_handle])
 
 
@@ -130,7 +131,7 @@ def barrier_arrive(
 
     arrive_count_ir = _semantic.builder.get_int32(int(arrive_count_val))
 
-    _semantic.builder.utlx_barrier_arrive([bar.handle, arrive_count_ir])
+    _semantic.builder.create_utlx_barrier_arrive([bar.handle, arrive_count_ir])
 
 
 @tl.builtin
@@ -143,7 +144,7 @@ def named_barrier_wait(
     bar_handle = _semantic._convert_elem_to_ir_value(bar, require_i64=False)
     arrive_count_handle = _semantic._convert_elem_to_ir_value(
         arrive_count, require_i64=False)
-    _semantic.builder.utlx_named_barrier_wait(
+    _semantic.builder.create_utlx_named_barrier_wait(
         [bar_handle, arrive_count_handle])
 
 
@@ -157,5 +158,5 @@ def named_barrier_arrive(
     bar_handle = _semantic._convert_elem_to_ir_value(bar, require_i64=False)
     arrive_count_handle = _semantic._convert_elem_to_ir_value(
         arrive_count, require_i64=False)
-    _semantic.builder.utlx_named_barrier_arrive(
+    _semantic.builder.create_utlx_named_barrier_arrive(
         [bar_handle, arrive_count_handle])

--- a/extensions/utlx/python/utlx_plugin/custom_stages.py
+++ b/extensions/utlx/python/utlx_plugin/custom_stages.py
@@ -63,7 +63,7 @@ def inspect_stages_hook(self=None,
             # Phase 1: Plugin ConvertTritonToTritonGPU
             pm = ir.pass_manager(mod.context)
             pm.enable_debug()
-            passes.plugin.utlx_convert_triton_to_tritongpu(
+            passes.plugin.add_utlx_convert_triton_to_tritongpu(
                 pm, [
                     f"hip:{target}",
                     str(options.num_warps),
@@ -84,7 +84,7 @@ def inspect_stages_hook(self=None,
             amd.passes.ttgpuir.add_accelerate_matmul(
                 pm, options.arch, options.matrix_instr_nonkdim, options.kpack)
             # uTLX: fix MemDesc encodings to match DotOp operand requirements
-            passes.plugin.utlx_insert_and_propagate_layout(pm, [])
+            passes.plugin.add_utlx_insert_and_propagate_layout(pm, [])
 
             passes.ttgpuir.add_remove_layout_conversions(pm)
             amd.passes.ttgpuir.add_optimize_epilogue(pm)
@@ -151,7 +151,7 @@ def inspect_stages_hook(self=None,
             mod = self.make_ttir(mod, metadata, opt, cap)
             pm = ir.pass_manager(mod.context)
             pm.enable_debug()
-            passes.plugin.utlx_convert_triton_to_tritongpu(
+            passes.plugin.add_utlx_convert_triton_to_tritongpu(
                 pm,
                 [f"cuda:{cap}",
                  str(opt.num_warps), '32',
@@ -170,8 +170,8 @@ def inspect_stages_hook(self=None,
         def make_llir_wrapper(mod, metadata):
             pm = ir.pass_manager(mod.context)
             pm.enable_debug()
-            passes.plugin.utlx_storage_alias_lowering(pm, [])
-            passes.plugin.utlx_rewrite_local_alias(pm, [])
+            passes.plugin.add_utlx_storage_alias_lowering(pm, [])
+            passes.plugin.add_utlx_rewrite_local_alias(pm, [])
             pm.run(mod, 'utlx_storage_alias')
             return original_llir(mod, metadata)
 

--- a/extensions/utlx/python/utlx_plugin/dynamic_launch.py
+++ b/extensions/utlx/python/utlx_plugin/dynamic_launch.py
@@ -12,7 +12,7 @@ def _alloc_clc_responses(num_responses: tl.constexpr,
                          _semantic=None) -> tlx.clc_response:
     layout = tlx.swizzled_shared_layout_encoding.make_default(rank=1)
     num_responses_val = tl._unwrap_if_constexpr(num_responses)
-    handle = _semantic.builder.utlx_alloc_clc_responses(
+    handle = _semantic.builder.create_utlx_alloc_clc_responses(
         [_semantic.builder.get_int32(int(num_responses_val))])
     return tlx.clc_response(handle, num_responses_val, layout)
 
@@ -20,14 +20,14 @@ def _alloc_clc_responses(num_responses: tl.constexpr,
 @tl.builtin
 def _clc_issue(clc_response_addr, barrier, _semantic=None):
     assert isinstance(clc_response_addr, tlx.clc_response)
-    _semantic.builder.utlx_async_clc_try_cancel(
+    _semantic.builder.create_utlx_async_clc_try_cancel(
         [barrier.handle, clc_response_addr.handle])
 
 
 @tl.builtin
 def _clc_query(clc_response_addr, _semantic=None):
     assert isinstance(clc_response_addr, tlx.clc_response)
-    x = _semantic.builder.utlx_clc_query([clc_response_addr.handle])
+    x = _semantic.builder.create_utlx_clc_query([clc_response_addr.handle])
     return tl.tensor(x, tl.int32)
 
 
@@ -62,7 +62,7 @@ def clc_producer(context,
     response = local_view(context._clc_responses, k, _semantic=_semantic)
 
     if multi_ctas:
-        cta_rank = _semantic.builder.utlx_cluster_cta_rank([])
+        cta_rank = _semantic.builder.create_utlx_cluster_cta_rank([])
         zero = _semantic.builder.get_int32(0)
         pred_cta0_handle = _semantic.builder.create_icmpEQ(cta_rank, zero)
         pred_cta0 = tl.tensor(pred_cta0_handle, tl.int1)

--- a/extensions/utlx/python/utlx_plugin/mem_ops.py
+++ b/extensions/utlx/python/utlx_plugin/mem_ops.py
@@ -58,7 +58,7 @@ def _assert_blackwell_for_tmem(arch):
 def _create_tmem_compatible_tensor_layout(builder,
                                           tensor: tlx.buffered_tensor):
     """Create a DummyRegisterLayout encoding for TMEM-compatible register layout."""
-    return builder.utlx_make_dummy_register_layout(
+    return builder.create_utlx_make_dummy_register_layout(
         [builder.get_int32(int(s)) for s in tensor.shape] +
         [_make_type_carrier(builder, tensor.dtype),
          builder.get_int32(1)])  # tmemCompatible=True
@@ -91,7 +91,8 @@ def storage_alias_spec(
         size_val = tl._unwrap_if_constexpr(buffer_size_bytes)
     size_ir = _semantic.builder.get_int64(size_val)
 
-    handle = _semantic.builder.utlx_storage_alias_spec([storage_ir, size_ir])
+    handle = _semantic.builder.create_utlx_storage_alias_spec(
+        [storage_ir, size_ir])
 
     return tlx.storage_alias_spec(
         handle,
@@ -139,7 +140,7 @@ def local_alloc(
     target_hint = _semantic.builder.get_int32(1 if is_amd else 0)
 
     args = [type_carrier] + shape_values + [target_hint]
-    tensor_handle = _semantic.builder.utlx_local_alloc(args)
+    tensor_handle = _semantic.builder.create_utlx_local_alloc(args)
 
     if len(unwrapped_shape) == 1 or is_amd:
         py_layout = tlx.swizzled_shared_layout_encoding.make_default(
@@ -161,7 +162,8 @@ def _local_alloc_with_storage_alias(semantic, spec, dtype, full_shape,
     storage_hint = semantic.builder.get_int32(1 if is_tmem else 0)
 
     args = [spec.handle, type_carrier] + shape_values + [storage_hint]
-    tensor_handle = semantic.builder.utlx_storage_alias_local_alloc(args)
+    tensor_handle = semantic.builder.create_utlx_storage_alias_local_alloc(
+        args)
 
     if is_tmem:
         py_layout = tlx.tensor_memory_layout_encoding.make_default(
@@ -191,7 +193,7 @@ def _local_alloc_tmem(semantic, dtype, full_shape, unwrapped_shape,
     layout_hint = semantic.builder.get_int32(1 if use_dummy else 0)
 
     args = [type_carrier] + shape_values + [layout_hint]
-    tensor_handle = semantic.builder.utlx_local_alloc_tmem(args)
+    tensor_handle = semantic.builder.create_utlx_local_alloc_tmem(args)
 
     if use_dummy:
         py_layout = tlx.DummyTMEMLayoutEncoding()
@@ -216,7 +218,7 @@ def _local_alloc_with_alias(semantic, reuse_tensor, dtype, full_shape,
     storage_hint = semantic.builder.get_int32(1 if is_tmem else 0)
 
     args = [reuse_tensor.handle, type_carrier] + shape_values + [storage_hint]
-    tensor_handle = semantic.builder.utlx_local_alias(args)
+    tensor_handle = semantic.builder.create_utlx_local_alias(args)
 
     if is_tmem:
         py_layout = tlx.tensor_memory_layout_encoding.make_default(
@@ -241,7 +243,7 @@ def local_view(
     """Returns a subview of the buffer at the given index."""
     buffer_idx = _semantic._convert_elem_to_ir_value(buffer_idx,
                                                      require_i64=False)
-    view_handle = _semantic.builder.utlx_local_view(
+    view_handle = _semantic.builder.create_utlx_local_view(
         [local_allocated_buffers.handle, buffer_idx])
 
     if isinstance(local_allocated_buffers, tlx.mbarrier):
@@ -286,7 +288,7 @@ def remote_view(
     assert local_allocated_buffer.type.storage == storage_kind.smem, "remote_view requires local smem as input"
     remote_cta_rank_handle = _get_remote_cta_rank_handle(
         remote_cta_rank, _semantic)
-    remote_buf_handle = _semantic.builder.utlx_map_to_remote_buffer(
+    remote_buf_handle = _semantic.builder.create_utlx_map_to_remote_buffer(
         [local_allocated_buffer.handle, remote_cta_rank_handle])
     return tlx.mbarrier(remote_buf_handle, 0,
                         local_allocated_buffer.type.layout,
@@ -305,7 +307,7 @@ def remote_shmem_store(
     assert remote_cta_rank is not None
     remote_cta_rank_handle = _get_remote_cta_rank_handle(
         remote_cta_rank, _semantic)
-    _semantic.builder.utlx_remote_shmem_store(
+    _semantic.builder.create_utlx_remote_shmem_store(
         [src.handle, dst.handle, remote_cta_rank_handle])
     return tl.tensor(src.handle, tl.void)
 
@@ -324,7 +326,7 @@ def async_remote_shmem_store(
     assert barrier is not None
     remote_cta_rank_handle = _get_remote_cta_rank_handle(
         remote_cta_rank, _semantic)
-    _semantic.builder.utlx_async_remote_shmem_store(
+    _semantic.builder.create_utlx_async_remote_shmem_store(
         [src.handle, dst.handle, remote_cta_rank_handle, barrier.handle])
     return tl.tensor(src.handle, tl.void)
 
@@ -462,7 +464,7 @@ def async_load(
 
         _semantic._str_to_load_cache_modifier(cache_modifier)
         _semantic._str_to_eviction_policy(eviction_policy)
-        token = _semantic.builder.utlx_async_load([
+        token = _semantic.builder.create_utlx_async_load([
             src.handle, result.handle, bulk_size_handle, barrier.handle,
             _semantic.builder.get_int32(1)
         ])  # useBulk=1
@@ -494,7 +496,7 @@ def async_load(
     if other is not None:
         args.append(other.handle)
     args.append(_semantic.builder.get_int32(0))  # useBulk=0
-    token = _semantic.builder.utlx_async_load(args)
+    token = _semantic.builder.create_utlx_async_load(args)
     return tlx.async_token(token)
 
 
@@ -509,7 +511,7 @@ def async_load_commit_group(
     handles = [
         t.handle for t in tokens if t is not None and t.handle is not None
     ]
-    result = _semantic.builder.utlx_async_commit_group(handles)
+    result = _semantic.builder.create_utlx_async_commit_group(handles)
     return tlx.async_token(result)
 
 
@@ -527,7 +529,7 @@ def async_load_wait_group(
         t.handle for t in tokens if t is not None and t.handle is not None
     ]
     args = [_semantic.builder.get_int32(pendings)] + handles
-    _semantic.builder.utlx_async_wait_group(args)
+    _semantic.builder.create_utlx_async_wait_group(args)
     return tlx.async_token(None)
 
 
@@ -546,13 +548,13 @@ def local_load(
             _semantic.builder, src)
         load_handle = _semantic.builder.create_tmem_load(
             src.handle, tmem_layout, token.handle if token else None)
-        output = _semantic.builder.utlx_release_layout([load_handle])
+        output = _semantic.builder.create_utlx_release_layout([load_handle])
         return tl.tensor(output, block_type)
     else:
         args = [src.handle]
         if token is not None and token.handle is not None:
             args.append(token.handle)
-        output = _semantic.builder.utlx_local_load(args)
+        output = _semantic.builder.create_utlx_local_load(args)
         return tl.tensor(output, block_type)
 
 
@@ -568,13 +570,13 @@ def local_store(
         _assert_blackwell_for_tmem(_semantic.builder.options.arch)
         tmem_layout = _create_tmem_compatible_tensor_layout(
             _semantic.builder, dst)
-        src_handle = _semantic.builder.utlx_require_with_layout_carrier(
+        src_handle = _semantic.builder.create_utlx_require_with_layout_carrier(
             [src.handle, tmem_layout])
         return tl.tensor(
             _semantic.builder.create_tmem_store(dst.handle, src_handle),
             tl.void)
 
-    _semantic.builder.utlx_local_store([dst.handle, src.handle])
+    _semantic.builder.create_utlx_local_store([dst.handle, src.handle])
     return tl.tensor(src.handle, tl.void)
 
 
@@ -611,7 +613,7 @@ def async_store(
     else:
         size_handle = _semantic._convert_elem_to_ir_value(size,
                                                           require_i64=False)
-    _semantic.builder.utlx_async_store(
+    _semantic.builder.create_utlx_async_store(
         [src_smem.handle, dst_global_ptr.handle, size_handle])
 
 
@@ -623,7 +625,8 @@ def fence(scope: tl.constexpr, _semantic=None) -> None:
         _semantic.builder.create_fence_async_shared(False)
     elif scope in ("gpu", "sys"):
         scope_val = 0 if scope == "gpu" else 1
-        _semantic.builder.utlx_fence([_semantic.builder.get_int32(scope_val)])
+        _semantic.builder.create_utlx_fence(
+            [_semantic.builder.get_int32(scope_val)])
     else:
         raise ValueError(
             f"fence scope must be 'gpu', 'sys', or 'async_shared', got '{scope}'"
@@ -650,7 +653,7 @@ def allocate_tensor_descriptor(
     nbytes = descriptor_size * unwrapped_num
     alignment = 128
 
-    tensor_handle = _semantic.builder.utlx_global_scratch_alloc([
+    tensor_handle = _semantic.builder.create_utlx_global_scratch_alloc([
         _semantic.builder.get_int32(nbytes),
         _semantic.builder.get_int32(alignment)
     ])
@@ -804,8 +807,8 @@ def async_descriptor_prefetch_tensor(
         pred_handle = _semantic.builder.get_int1(True)
     else:
         pred_handle = pred.handle
-    _semantic.builder.utlx_async_tma_prefetch([desc.handle] + offsets +
-                                              [pred_handle])
+    _semantic.builder.create_utlx_async_tma_prefetch([desc.handle] + offsets +
+                                                     [pred_handle])
 
 
 @tl.builtin

--- a/extensions/utlx/python/utlx_plugin/mma_ops.py
+++ b/extensions/utlx/python/utlx_plugin/mma_ops.py
@@ -35,7 +35,7 @@ def require_nv_mma_shared_layout(x, swizzled, _builder=None, fp4Padded=False):
         swizzled=swizzled,
     )
     # Combined custom op: creates encoding + RequireLayoutOp in one step
-    result = _builder.utlx_require_nv_mma_shared_layout(
+    result = _builder.create_utlx_require_nv_mma_shared_layout(
         [x.handle] + [_builder.get_int32(int(s)) for s in layout.shape] +
         [_builder.get_int32(o) for o in layout.order] + [
             _builder.get_int32(1 if layout.fp4Padded else 0),
@@ -48,7 +48,7 @@ def require_nv_mma_shared_layout(x, swizzled, _builder=None, fp4Padded=False):
 
 def require_dot_operand_layout(opnd, opIdx, parent_value, _builder=None):
     # parent_value is a Value whose type carries the parent NvidiaMmaEncoding
-    result = _builder.utlx_require_dot_operand_layout(
+    result = _builder.create_utlx_require_dot_operand_layout(
         [opnd.handle, _builder.get_int32(opIdx), parent_value])
     if result is not None:
         return result
@@ -61,7 +61,7 @@ def require_tmem_layout_col_stride(src, col_stride, _builder=None):
             and isinstance(src.type.layout, tlx.tensor_memory_layout_encoding))
     old_layout = src.type.layout
     if old_layout.colStride != col_stride:
-        result = _builder.utlx_require_tensor_memory_layout([
+        result = _builder.create_utlx_require_tensor_memory_layout([
             src.handle,
             _builder.get_int32(old_layout.blockM),
             _builder.get_int32(old_layout.blockN),
@@ -77,7 +77,8 @@ def require_tmem_layout_col_stride(src, col_stride, _builder=None):
 def require_tmem_scales_layout(src, _builder=None):
     assert isinstance(
         src, tlx.buffered_tensor) and src.type.storage == tlx.storage_kind.tmem
-    result = _builder.utlx_require_tensor_memory_scales_layout([src.handle])
+    result = _builder.create_utlx_require_tensor_memory_scales_layout(
+        [src.handle])
     if result is not None:
         return result
     return src.handle
@@ -142,7 +143,7 @@ def async_dot(
         return tl.tensor(acc_handle, tl.void)
     else:
         # Create NvidiaMma encoding and apply it to acc via combined custom op
-        acc_with_layout = _semantic.builder.utlx_require_nv_mma_layout([
+        acc_with_layout = _semantic.builder.create_utlx_require_nv_mma_layout([
             A_handle, acc_handle,
             _semantic.builder.get_int32(version),
             _semantic.builder.get_int32(0),
@@ -156,7 +157,7 @@ def async_dot(
         output = _semantic.builder.create_warpgroup_mma(
             A_handle, B_handle, acc_with_layout, None, input_precision,
             max_num_imprecise_acc, True)
-        output = _semantic.builder.utlx_release_layout([output])
+        output = _semantic.builder.create_utlx_release_layout([output])
         return tl.tensor(output, ret_ty)
 
 
@@ -244,7 +245,7 @@ def async_dot_wait(pendings: tl.constexpr,
     """Wait for completion of prior asynchronous dot operations."""
     pendings = tl._unwrap_if_constexpr(pendings)
     # Use custom op that handles ReleaseLayoutOp unwrap/rewire
-    result = _semantic.builder.utlx_warp_group_dot_wait(
+    result = _semantic.builder.create_utlx_warp_group_dot_wait(
         [inp.handle, _semantic.builder.get_int32(pendings)])
     return tl.tensor(result, inp.type)
 
@@ -255,7 +256,7 @@ def tcgen05_commit(mBarrier, two_ctas=False, _semantic=None) -> tl.tensor:
     if not two_ctas:
         pred_handle = _semantic.builder.get_int1(True)
     else:
-        cta_rank = _semantic.builder.utlx_cluster_cta_rank([])
+        cta_rank = _semantic.builder.create_utlx_cluster_cta_rank([])
         mod_result = _semantic.builder.create_urem(
             cta_rank, _semantic.builder.get_int32(2))
         pred_handle = _semantic.builder.create_icmpEQ(

--- a/extensions/utlx/python/utlx_plugin/types.py
+++ b/extensions/utlx/python/utlx_plugin/types.py
@@ -352,7 +352,7 @@ class reuse_group:
         group_size_ir = builder.get_int32(self._group_size)
 
         args = [group_kind_ir, group_size_ir] + ir_elements
-        return builder.utlx_reuse_group(args)
+        return builder.create_utlx_reuse_group(args)
 
 
 class buffered_tensor(tl.base_value):
@@ -618,7 +618,7 @@ class storage_alias_spec(tl.base_value):
 
         overlap_def_ir = overlap_def.to_ir(_semantic.builder)
         # Call the plugin custom op
-        _semantic.builder.utlx_set_buffer_overlap(
+        _semantic.builder.create_utlx_set_buffer_overlap(
             [self._handle, overlap_def_ir])
 
     def _flatten_ir(self, handles):

--- a/extensions/utlx/python/utlx_plugin/utility.py
+++ b/extensions/utlx/python/utlx_plugin/utility.py
@@ -34,12 +34,14 @@ def cuda_parse_arch(arch):
 
 @tl.builtin
 def cluster_cta_rank(_semantic=None):
-    return tl.tensor(_semantic.builder.utlx_cluster_cta_rank([]), tl.int32)
+    return tl.tensor(_semantic.builder.create_utlx_cluster_cta_rank([]),
+                     tl.int32)
 
 
 @tl.builtin
 def cluster_size_1d(_semantic=None):
-    return tl.tensor(_semantic.builder.utlx_cluster_size_1d([]), tl.int32)
+    return tl.tensor(_semantic.builder.create_utlx_cluster_size_1d([]),
+                     tl.int32)
 
 
 @tl.builtin
@@ -48,8 +50,8 @@ def thread_id(axis, _semantic=None):
     if axis not in (0, 1, 2):
         raise ValueError(f"thread_id axis must be 0, 1, or 2 but got {axis}")
     return tl.tensor(
-        _semantic.builder.utlx_thread_id([_semantic.builder.get_int32(axis)]),
-        tl.int32)
+        _semantic.builder.create_utlx_thread_id(
+            [_semantic.builder.get_int32(axis)]), tl.int32)
 
 
 @tl.builtin
@@ -107,7 +109,7 @@ def get_fp8_format_name(dtype: tl.dtype, _semantic=None) -> tl.constexpr:
 
 @tl.builtin
 def clock64(_semantic=None):
-    return tl.tensor(_semantic.builder.utlx_clock64([]), tl.int64)
+    return tl.tensor(_semantic.builder.create_utlx_clock64([]), tl.int64)
 
 
 @tl.builtin
@@ -145,7 +147,7 @@ def stoch_round(
         result_ty = dst_ty
         dst_ir_ty = dst_ty.to_ir(_semantic.builder)
     # Use fp_to_fp with rounding=RS (stochastic), mode=2
-    dst = _semantic.builder.utlx_fp_to_fp_with_rbits([
+    dst = _semantic.builder.create_utlx_fp_to_fp_with_rbits([
         _semantic.builder.get_null_value(dst_ir_ty), src.handle,
         rand_bits.handle,
         _semantic.builder.get_int32(2)

--- a/extensions/utlx/python/utlx_plugin/warp_ops.py
+++ b/extensions/utlx/python/utlx_plugin/warp_ops.py
@@ -19,7 +19,7 @@ def vote_ballot_sync(
         mask_val = mask
 
     mask_handle = _semantic.builder.get_int32(mask_val)
-    result = _semantic.builder.utlx_vote_ballot_sync(
+    result = _semantic.builder.create_utlx_vote_ballot_sync(
         [mask_handle, pred.handle])
 
     if pred.type.is_block():


### PR DESCRIPTION
PRs [#10737] and [#10754] automatically prepend `add_` and `create_` verbs so that the Triton functions exposed by an extension would match how Triton names its own functions. This change applies the new names to utlx; other extensions already have this but the lack of tests for utlx mean this issue did not appear until running a @crobeck [gist].

[#10754]: https://github.com/triton-lang/triton/pull/10754
[#10737]: https://github.com/triton-lang/triton/pull/10737
[gist]: https://gist.github.com/CRobeck/daec7724bd3fd1ef2b38af7024032bc4