### PR TITLE
ci: pick a wheel commit with the right architecture

### DIFF
--- a/ci/download_triton_wheel.py
+++ b/ci/download_triton_wheel.py
@@ -28,7 +28,6 @@ Usage (NOTE: quote the pattern to avoid shell expansion):
 import logging
 import os
 import sys
-from fnmatch import fnmatch
 
 import common
 import list_triton_wheels as wheels
@@ -62,30 +61,6 @@ def normalize_arch(arch):
         return "aarch64"
     LOG.error(f"Unrecognised arch: {arch!r}; expected 'x64' or 'arm64'")
     sys.exit(1)
-
-
-def select_wheel(candidates: list[wheels.Wheel],
-                 pattern: str) -> wheels.Wheel | None:
-    """
-    Return the first wheel in `candidates` that matches the `pattern`.
-
-    >>> select_wheel([], "triton-*") is None
-    True
-    >>> select_wheel([wheels.Wheel("triton-3.8.0-cp314-...whl", "https://...")], "triton-*").version()
-    '3.8.0'
-    >>> select_wheel([
-    ...   wheels.Wheel("triton-3.8.0+gitf6ef5434-...x86_64.whl", "https://..."),
-    ...   wheels.Wheel("triton-3.8.0+gitf6ef5434-...aarch64.whl", "https://..."),
-    ... ], "triton-*f6ef5434*aarch64*").filename
-    'triton-3.8.0+gitf6ef5434-...aarch64.whl'
-    >>>
-    """
-    LOG.debug(f"Searching for pattern: {pattern}")
-    for wheel in candidates:
-        if fnmatch(wheel.filename, pattern):
-            LOG.debug(f"Found: {wheel}")
-            return wheel
-    return None
 
 
 def download_wheel(url, filename, channel):
@@ -123,11 +98,11 @@ def main(
         print(USAGE, file=sys.stderr)
         sys.exit(1)
 
-    candidates = wheels.run(channel)
-    wheel = select_wheel(candidates, pattern)
-    if not wheel:
+    candidates = wheels.run(channel, pattern)
+    if not candidates:
         LOG.error(f"No wheel found matching pattern: {pattern}")
         sys.exit(1)
+    wheel = candidates[0]
 
     if not dry_run:
         download_wheel(wheel.url, wheel.filename, channel)

--- a/ci/fetch_triton_hash.py
+++ b/ci/fetch_triton_hash.py
@@ -17,6 +17,7 @@ from datetime import datetime
 
 import common
 import list_triton_wheels as wheels
+import probe_sysinfo
 
 LOG = logging.getLogger(os.path.basename(__file__))
 
@@ -75,8 +76,11 @@ def run(repo: str, depth: int) -> str | None:
         commits = scan(tmpdir)
         sorted_by_date = sorted(commits, key=lambda x: x.date, reverse=True)
 
-    candidates = wheels.run("nightly")
-    LOG.debug(f"Found {len(candidates)} nightly wheels")
+    _, probed_arch = probe_sysinfo.run()
+    arch = "x86_64" if probed_arch == "x64" else "aarch64"
+    arch_pattern = f"*_{arch}*.whl"
+    candidates = wheels.run("nightly", arch_pattern)
+    LOG.debug(f"Found {len(candidates)} nightly wheels for {arch}")
     for commit in sorted_by_date:
         LOG.debug(f"Checking commit: {commit.hash} ({commit.date})")
         short = commit.hash[:8]

--- a/ci/list_triton_wheels.py
+++ b/ci/list_triton_wheels.py
@@ -11,7 +11,7 @@ fetches a list of wheels for a given channel (a `PEP 503`_ index). When run as a
 script it prints the retrieved wheel names to stdout.
 
 Usage:
-    python ci/list_triton_wheels.py [nightly|release]
+    python ci/list_triton_wheels.py [nightly|release] ['wheel-pattern']
 
 .. _feed: https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/Triton-Nightly/pypi/simple/triton/
 .. _PEP 503: https://peps.python.org/pep-0503/
@@ -22,6 +22,7 @@ import logging
 import os
 import sys
 from dataclasses import dataclass
+from fnmatch import fnmatch
 from html.parser import HTMLParser
 
 import requests
@@ -78,8 +79,7 @@ class Wheel:
         ('cp314', 'cp314', 'linux_x86_64')
         """
         stem = self.filename.rsplit(".", 1)[0]
-        interpreter, abi, platform, remaining = stem.split("-")[2:]
-        assert not remaining
+        interpreter, abi, platform = stem.split("-")[2:]
         return (interpreter, abi, platform)
 
 
@@ -129,11 +129,32 @@ def _parse_anchors(html: str) -> list[Wheel]:
     return parser.results
 
 
-def run(channel) -> list[Wheel]:
-    """Return all wheel entries for the given channel."""
+def _filter_wheels(candidates: list[Wheel], pattern: str) -> list[Wheel]:
+    """
+    Return the subset of `candidates` whose filenames match `pattern`.
+
+    >>> _filter_wheels([], "triton-*")
+    []
+    >>> _filter_wheels([Wheel("triton-3.8.0-cp314-...whl", "https://...")], "triton-*")[0].version()
+    '3.8.0'
+    >>> wheels = [
+    ...   Wheel("triton-3.8.0+gitf6ef5434-...x86_64.whl", "https://..."),
+    ...   Wheel("triton-3.8.0+gitf6ef5434-...aarch64.whl", "https://..."),
+    ... ]
+    >>> _filter_wheels(wheels, "triton-*f6ef5434*aarch64*")[0].filename
+    'triton-3.8.0+gitf6ef5434-...aarch64.whl'
+    """
+    return [w for w in candidates if fnmatch(w.filename, pattern)]
+
+
+def run(channel, pattern=None) -> list[Wheel]:
+    """Return all wheel entries for the given channel, optionally filtered by pattern."""
     html = _fetch_index(channel)
     wheels = _parse_anchors(html)
     LOG.debug(f"Parsed {len(wheels)} wheel anchors from {channel} index")
+    if pattern:
+        wheels = _filter_wheels(wheels, pattern)
+        LOG.debug(f"Filtered to {len(wheels)} wheels matching: {pattern}")
     return wheels
 
 
@@ -152,9 +173,11 @@ if __name__ == "__main__":
 
     channel = sys.argv[1] if len(sys.argv) > 1 else "nightly"
     if channel not in CHANNELS:
-        print("Usage: python ci/list_triton_wheels.py [nightly|release]",
-              file=sys.stderr)
+        print(
+            "Usage: python ci/list_triton_wheels.py [nightly|release] ['wheel-pattern']",
+            file=sys.stderr)
         sys.exit(1)
 
-    for wheel in run(channel):
+    pattern = sys.argv[2] if len(sys.argv) > 2 else None
+    for wheel in run(channel, pattern):
         print(wheel)


### PR DESCRIPTION
As documented in #117, the automatic task that updates the Triton pin was getting confused about which wheel to pick: it would pick a nightly wheel with an invalid architecture for the GitHub runner being used (i.e., x86_64). Presumably this happens because upstream builds wheels for different architectures at different times, resulting in different commits (?). This change moves the filtering logic for selecting wheels in to `ci/list_triton_wheels.py` so it can be used for picking a valid wheel in `ci/fetch_triton_hash.py`.

Resolves #117.