### PR TITLE
Run all available doctests during `pre-commit`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,22 +29,6 @@ jobs:
         if: failure()
         run: git diff
 
-  check-manifests:
-    name: Check extension manifests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6.0.2
-      - uses: actions/setup-python@v6
-        with:
-          python-version: '3.12'
-      - name: Install dependencies
-        run: python -m pip install -r requirements.txt
-      - name: Run manifest doctests
-        run: python ci/extension.py
-      - name: Parse manifests
-        run: python ci/list_extensions.py
-
   build:
     name: Build on ${{ matrix.config.runner }}
     runs-on: ${{ matrix.config.runs_on }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,5 +63,11 @@ repos:
         entry: ci/list_extensions.py
         language: python
         pass_filenames: false
+      - id: doctests
+        name: run doctests
+        entry: ci/doctests.py
+        language: python
+        additional_dependencies: [requests]
+        pass_filenames: false
 
 exclude: '^$'

--- a/ci/doctests.py
+++ b/ci/doctests.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""
+Run the doctests for all scripts that have them in this directory.
+
+Every script with doctests can also be run with `DOCTEST=1 python ...`. After
+finding all scripts `import doctest`, this script runs each one as a separate
+subprocess.
+
+Usage:
+    python ci/doctests.py
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+
+
+def has_doctests(script: Path) -> bool:
+    """Return whether a script opts in to doctests by importing `doctest`."""
+    if script.resolve() == Path(__file__).resolve():
+        return False
+    text = script.read_text(encoding="utf-8")
+    has_doctest = "import doctest" in text
+    assert not has_doctest or 'common.env2bool("DOCTEST")' in text
+    return has_doctest
+
+
+def test(script: Path) -> bool:
+    print(f"Testing {script}", file=sys.stderr)
+    env = dict(os.environ, DOCTEST="1")
+    result = subprocess.run([sys.executable, script], env=env, check=False)
+    return result.returncode == 0
+
+
+def main() -> int:
+    scripts = sorted(s for s in HERE.glob("*.py") if has_doctests(s))
+    for script in scripts:
+        if not test(script):
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/download_triton_wheel.py
+++ b/ci/download_triton_wheel.py
@@ -25,6 +25,7 @@ Usage (NOTE: quote the pattern to avoid shell expansion):
     python ci/download_triton_wheel.py [channel] ['wheel-pattern']
 """
 
+import doctest
 import logging
 import os
 import sys
@@ -141,9 +142,8 @@ if __name__ == "__main__":
     if common.env2bool("VERBOSE"):
         logging.basicConfig(level=logging.DEBUG)
 
-    if common.env2bool("TEST"):
-        import doctest
-        results = doctest.testmod()
+    if common.env2bool("DOCTEST"):
+        results = doctest.testmod()  # type: ignore[attr-defined]
         sys.exit(int(results.failed > 0))
 
     dry_run = common.env2bool("DRY_RUN")

--- a/ci/extension.py
+++ b/ci/extension.py
@@ -6,11 +6,14 @@ This also understands parsing a CODEOWNERS file to associate a list of owners
 with an extension: see :parse_codeowners: and :owners_for:.
 """
 
+import doctest
 import logging
 import os
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 
+import common
 import tomllib
 
 VALID_STATUS = {"experimental", "stable"}
@@ -184,6 +187,6 @@ def discover() -> list[Manifest]:
 
 
 if __name__ == "__main__":
-    """Running this file will run the inline doctests."""
-    import doctest
-    doctest.testmod()
+    if common.env2bool("DOCTEST"):
+        results = doctest.testmod()  # type: ignore[attr-defined]
+        sys.exit(int(results.failed > 0))

--- a/ci/list_triton_wheels.py
+++ b/ci/list_triton_wheels.py
@@ -18,6 +18,7 @@ Usage:
 .. _PyPI: https://pypi.org/simple/triton/
 """
 
+import doctest
 import logging
 import os
 import sys
@@ -78,8 +79,7 @@ class Wheel:
         ('cp314', 'cp314', 'linux_x86_64')
         """
         stem = self.filename.rsplit(".", 1)[0]
-        interpreter, abi, platform, remaining = stem.split("-")[2:]
-        assert not remaining
+        interpreter, abi, platform = stem.split("-")[2:]
         return (interpreter, abi, platform)
 
 
@@ -145,9 +145,8 @@ if __name__ == "__main__":
     if common.env2bool("VERBOSE"):
         logging.basicConfig(level=logging.DEBUG)
 
-    if common.env2bool("TEST"):
-        import doctest
-        results = doctest.testmod()
+    if common.env2bool("DOCTEST"):
+        results = doctest.testmod()  # type: ignore[attr-defined]
         sys.exit(int(results.failed > 0))
 
     channel = sys.argv[1] if len(sys.argv) > 1 else "nightly"


### PR DESCRIPTION
This simple check ensures doctests in our CI scripts stay green. It finds any scripts that `import doctest` and runs them with `DOCTEST=1`. This means that for each script with doctests must inspect the `DOCTEST` environment and run `doctest.testmod()`, returning an appropriate exit code. This allows us to avoid an extra CI job; all doctests and extension checks run as a part of `pre-commit`.